### PR TITLE
Update to latest MLIR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,22 +30,26 @@ jobs:
           command: gcc --version
 
       - restore_cache:
-          key: ONNF-MLIR-{{ arch }}
+          key: LLVM-PROJECT-{{ arch }}
       - run:
           name: Install MLIR
           command: |
             if [ ! -f llvm-project/build/bin/mlir-opt ]; then
-              git clone https://github.com/llvm/llvm-project.git  
-              cd llvm-project && git checkout 9b6ad8466bb8b97082b705270603ad7f4559e931 && cd ..
-              git clone https://github.com/tensorflow/mlir llvm-project/llvm/projects/mlir 
-              cd llvm-project/llvm/projects/mlir && git checkout 0710266d0f56cf6ab0f437badbd7416b6cecdf5f && cd ../../../..
-              mkdir llvm-project/build 
-              cd llvm-project/build 
-              cmake -G Ninja ../llvm -DLLVM_ENABLE_RTTI=ON  -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_BUILD_TYPE=Release
-              CMAKE_EXE_LINKER_FLAGS="-Wl,--reduce-memory-overheads -Wl,--hash-size=512" cmake --build . --target check-mlir -- -j 4
+              git clone https://github.com/llvm/llvm-project.git
+              mkdir llvm-project/build
+              cd llvm-project/build
+              cmake -G Ninja ../llvm \
+                 -DLLVM_ENABLE_PROJECTS=mlir \
+                 -DLLVM_BUILD_EXAMPLES=ON \
+                 -DLLVM_TARGETS_TO_BUILD="host" \
+                 -DCMAKE_BUILD_TYPE=Release \
+                 -DLLVM_ENABLE_ASSERTIONS=ON \
+                 -DLLVM_ENABLE_RTTI=ON
+              # TODO(tjingrant): why is RTTI necessary?
+              cmake --build . --target check-mlir
             fi
       - save_cache:
-          key: ONNF-MLIR-{{ arch }}
+          key: LLVM-PROJECT-{{ arch }}
           paths:
             - llvm-project
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,25 +7,26 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Pull Submodules"
+          name: Pull Submodules
           command: |
             git submodule update --init --recursive
       - run:
           name: Installing GCC, CMake, Ninja, Protobuf
-          command: 'sudo apt-get update && sudo apt-get install -y gcc g++ cmake ninja-build protobuf-compiler'
+          command: sudo apt-get update && sudo apt-get install -y gcc g++ cmake ninja-build protobuf-compiler
       # Use cached mlir installation if possible.
       - restore_cache:
-          key: V1-LLVM-PROJECT-{{ arch }}
+          key: V2-LLVM-PROJECT-{{ arch }}
       - run:
           name: Install MLIR
           command: |
             # Check whether cache restoration succeeds by checking whether
             # mlir-opt executable exists.
             if [ ! -f llvm-project/build/bin/mlir-opt ]; then
-              sh .circleci/install-mlir.sh
+              export MAKEFLAGS=-j4
+              source .circleci/install-mlir.sh
             fi
       - save_cache:
-          key: V1-LLVM-PROJECT-{{ arch }}
+          key: V2-LLVM-PROJECT-{{ arch }}
           paths:
             - llvm-project
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,45 +11,21 @@ jobs:
           command: |
             git submodule update --init --recursive
       - run:
-          name: Check current directory
-          command: pwd
-      - run:
-          name: Check current directory content
-          command: ls
-      - run:
-          name: Installing GCC
-          command: 'sudo apt-get update && sudo apt-get install -y gcc g++'
-      - run:
-          name: Install CMAKE
-          command: 'sudo apt-get update && sudo apt-get install -y cmake ninja-build'
-      - run:
-          name: Install Protobuf
-          command: 'sudo apt-get update && sudo apt-get install -y protobuf-compiler'
-      - run:
-          name: Check gcc version
-          command: gcc --version
-
+          name: Installing GCC, CMake, Ninja, Protobuf
+          command: 'sudo apt-get update && sudo apt-get install -y gcc g++ cmake ninja-build protobuf-compiler'
+      # Use cached mlir installation if possible.
       - restore_cache:
-          key: LLVM-PROJECT-{{ arch }}
+          key: V1-LLVM-PROJECT-{{ arch }}
       - run:
           name: Install MLIR
           command: |
+            # Check whether cache restoration succeeds by checking whether
+            # mlir-opt executable exists.
             if [ ! -f llvm-project/build/bin/mlir-opt ]; then
-              git clone https://github.com/llvm/llvm-project.git
-              mkdir llvm-project/build
-              cd llvm-project/build
-              cmake -G Ninja ../llvm \
-                 -DLLVM_ENABLE_PROJECTS=mlir \
-                 -DLLVM_BUILD_EXAMPLES=ON \
-                 -DLLVM_TARGETS_TO_BUILD="host" \
-                 -DCMAKE_BUILD_TYPE=Release \
-                 -DLLVM_ENABLE_ASSERTIONS=ON \
-                 -DLLVM_ENABLE_RTTI=ON
-              # TODO(tjingrant): why is RTTI necessary?
-              cmake --build . --target check-mlir -- -j 4
+              sh .circleci/install-mlir.sh
             fi
       - save_cache:
-          key: LLVM-PROJECT-{{ arch }}
+          key: V1-LLVM-PROJECT-{{ arch }}
           paths:
             - llvm-project
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: Install ONNF
           command: |
             mkdir build && cd build
-            LLVM_SRC=$(pwd)/../llvm-project/llvm LLVM_BUILD=$(pwd)/../llvm-project/build cmake ..
+            LLVM_PROJ_SRC=$(pwd)/../llvm-project/ LLVM_PROJ_BUILD=$(pwd)/../llvm-project/build cmake ..
             make all
             LIT_OPTS=-v make check-mlir-lit
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
                  -DLLVM_ENABLE_ASSERTIONS=ON \
                  -DLLVM_ENABLE_RTTI=ON
               # TODO(tjingrant): why is RTTI necessary?
-              cmake --build . --target check-mlir
+              cmake --build . --target check-mlir -- -j 4
             fi
       - save_cache:
           key: LLVM-PROJECT-{{ arch }}

--- a/.circleci/install-mlir.sh
+++ b/.circleci/install-mlir.sh
@@ -8,5 +8,5 @@ cmake -G Ninja ../llvm \
    -DCMAKE_BUILD_TYPE=Release \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DLLVM_ENABLE_RTTI=ON
-# TODO(tjingrant): why is RTTI necessary?
-cmake --build . --target check-mlir -- -j ${PARALLEL_JOBS_LIMIT:-4}
+
+cmake --build . --target check-mlir

--- a/.circleci/install-mlir.sh
+++ b/.circleci/install-mlir.sh
@@ -9,4 +9,5 @@ cmake -G Ninja ../llvm \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DLLVM_ENABLE_RTTI=ON
 
+export MAKEFLAGS=-j4
 cmake --build . --target check-mlir

--- a/.circleci/install-mlir.sh
+++ b/.circleci/install-mlir.sh
@@ -1,0 +1,12 @@
+git clone https://github.com/llvm/llvm-project.git
+mkdir llvm-project/build
+cd llvm-project/build
+cmake -G Ninja ../llvm \
+   -DLLVM_ENABLE_PROJECTS=mlir \
+   -DLLVM_BUILD_EXAMPLES=ON \
+   -DLLVM_TARGETS_TO_BUILD="host" \
+   -DCMAKE_BUILD_TYPE=Release \
+   -DLLVM_ENABLE_ASSERTIONS=ON \
+   -DLLVM_ENABLE_RTTI=ON
+# TODO(tjingrant): why is RTTI necessary?
+cmake --build . --target check-mlir -- -j ${PARALLEL_JOBS_LIMIT:-4}

--- a/.circleci/install-mlir.sh
+++ b/.circleci/install-mlir.sh
@@ -9,5 +9,4 @@ cmake -G Ninja ../llvm \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DLLVM_ENABLE_RTTI=ON
 
-export MAKEFLAGS='-j4'
-cmake --build . --target check-mlir
+cmake --build . --target check-mlir -- ${MAKEFLAGS}

--- a/.circleci/install-mlir.sh
+++ b/.circleci/install-mlir.sh
@@ -9,5 +9,5 @@ cmake -G Ninja ../llvm \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DLLVM_ENABLE_RTTI=ON
 
-export MAKEFLAGS=-j4
+export MAKEFLAGS='-j4'
 cmake --build . --target check-mlir

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -30,8 +30,8 @@ set(LLVM_PROJECT_LIB ${LLVM_BUILD}/lib)
 # Include paths for MLIR
 set(LLVM_SRC_INCLUDE_PATH ${LLVM_SRC}/include)
 set(LLVM_BIN_INCLUDE_PATH ${LLVM_BUILD}/include)
-set(MLIR_SRC_INCLUDE_PATH ${LLVM_SRC}/projects/mlir/include)
-set(MLIR_BIN_INCLUDE_PATH ${LLVM_BUILD}/projects/mlir/include)
+set(MLIR_SRC_INCLUDE_PATH ${LLVM_SRC}/../mlir/include)
+set(MLIR_BIN_INCLUDE_PATH ${LLVM_BUILD}/tools/mlir/include)
 set(MLIR_TOOLS_DIR ${LLVM_BUILD}/bin)
 
 set(ONNF_TOOLS_DIR ${ONNF_BIN_ROOT}/bin)

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -1,38 +1,38 @@
 # Path to LLVM source folder.
-if(DEFINED ENV{LLVM_SRC})
-  set(LLVM_SRC $ENV{LLVM_SRC})
-  if(EXISTS ${LLVM_SRC})
-    message(STATUS "LLVM_SRC " ${LLVM_SRC})
+if(DEFINED ENV{LLVM_PROJ_SRC})
+  set(LLVM_PROJ_SRC $ENV{LLVM_PROJ_SRC})
+  if(EXISTS ${LLVM_PROJ_SRC})
+    message(STATUS "LLVM_PROJ_SRC " ${LLVM_PROJ_SRC})
   else()
-    message(FATAL_ERROR "The path specified by LLVM_SRC does not exist: "
-            ${LLVM_SRC})
+    message(FATAL_ERROR "The path specified by LLVM_PROJ_SRC does not exist: "
+            ${LLVM_PROJ_SRC})
   endif()
 else()
-  message(FATAL_ERROR "env variable LLVM_SRC not set")
+  message(FATAL_ERROR "env variable LLVM_PROJ_SRC not set")
 endif()
 
 # Path to LLVM build folder
-if(DEFINED ENV{LLVM_BUILD})
-  set(LLVM_BUILD $ENV{LLVM_BUILD})
-  if(EXISTS ${LLVM_BUILD})
-    message(STATUS "LLVM_BUILD " ${LLVM_BUILD})
+if(DEFINED ENV{LLVM_PROJ_BUILD})
+  set(LLVM_PROJ_BUILD $ENV{LLVM_PROJ_BUILD})
+  if(EXISTS ${LLVM_PROJ_BUILD})
+    message(STATUS "LLVM_PROJ_BUILD " ${LLVM_PROJ_BUILD})
   else()
-    message(FATAL_ERROR "The path specified by LLVM_BUILD does not exist: "
-            ${LLVM_BUILD})
+    message(FATAL_ERROR "The path specified by LLVM_PROJ_BUILD does not exist: "
+            ${LLVM_PROJ_BUILD})
   endif()
 else()
-  message(FATAL_ERROR "env variable LLVM_BUILD not set")
+  message(FATAL_ERROR "env variable LLVM_PROJ_BUILD not set")
 endif()
 
 # LLVM project lib folder
-set(LLVM_PROJECT_LIB ${LLVM_BUILD}/lib)
+set(LLVM_PROJECT_LIB ${LLVM_PROJ_BUILD}/lib)
 
 # Include paths for MLIR
-set(LLVM_SRC_INCLUDE_PATH ${LLVM_SRC}/include)
-set(LLVM_BIN_INCLUDE_PATH ${LLVM_BUILD}/include)
-set(MLIR_SRC_INCLUDE_PATH ${LLVM_SRC}/../mlir/include)
-set(MLIR_BIN_INCLUDE_PATH ${LLVM_BUILD}/tools/mlir/include)
-set(MLIR_TOOLS_DIR ${LLVM_BUILD}/bin)
+set(LLVM_SRC_INCLUDE_PATH ${LLVM_PROJ_SRC}/llvm/include)
+set(LLVM_BIN_INCLUDE_PATH ${LLVM_PROJ_BUILD}/include)
+set(MLIR_SRC_INCLUDE_PATH ${LLVM_PROJ_SRC}/mlir/include)
+set(MLIR_BIN_INCLUDE_PATH ${LLVM_PROJ_BUILD}/tools/mlir/include)
+set(MLIR_TOOLS_DIR ${LLVM_PROJ_BUILD}/bin)
 
 set(ONNF_TOOLS_DIR ${ONNF_BIN_ROOT}/bin)
 set(ONNF_LIT_TEST_SRC_DIR ${CMAKE_SOURCE_DIR}/test/mlir)
@@ -173,7 +173,7 @@ function(whole_archive_link target lib_dir)
 endfunction(whole_archive_link)
 
 function(whole_archive_link_mlir target)
-  whole_archive_link(${target} ${LLVM_BUILD}/lib ${ARGN})
+  whole_archive_link(${target} ${LLVM_PROJ_BUILD}/lib ${ARGN})
 endfunction(whole_archive_link_mlir)
 
 function(whole_archive_link_onnf target)
@@ -184,7 +184,7 @@ function(whole_archive_link_onnf target)
 endfunction(whole_archive_link_onnf)
 
 set(LLVM_CMAKE_DIR
-        "${LLVM_BUILD}/lib/cmake/llvm"
+        "${LLVM_PROJ_BUILD}/lib/cmake/llvm"
         CACHE PATH "Path to LLVM cmake modules")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(AddLLVM)
@@ -205,5 +205,5 @@ endfunction()
 # table gen utility itself can be detected and cause re-compilation of .td file.
 add_executable(mlir-tblgen IMPORTED)
 set_property(TARGET mlir-tblgen
-        PROPERTY IMPORTED_LOCATION ${LLVM_BUILD}/bin/mlir-tblgen)
+        PROPERTY IMPORTED_LOCATION ${LLVM_PROJ_BUILD}/bin/mlir-tblgen)
 set(MLIR_TABLEGEN_EXE mlir-tblgen)

--- a/src/builder/frontend_dialect_transformer.cpp
+++ b/src/builder/frontend_dialect_transformer.cpp
@@ -71,7 +71,7 @@ struct OnnxOnnfSymbolMapping {
    *  @param name onnx tensor name.
    *  @return onnf tensor corresponding to `name`.
    */
-  mlir::Value *GetTensorByOnnxName(std::string name) {
+  mlir::Value GetTensorByOnnxName(std::string name) {
     assert(onnx_name2onnf_tensor.find(legalize_name(name)) !=
                             onnx_name2onnf_tensor.end() &&
                         "Tensor not found");
@@ -81,9 +81,9 @@ struct OnnxOnnfSymbolMapping {
   /*!
    *  Add a new mapping from onnx tensor name to MLIR symbol.
    *  @param name onnx tensor name.
-   *  @param tensor MLIR Value* pointer.
+   *  @param tensor MLIR Value  pointer.
    */
-  void AddMapping(std::string name, mlir::Value *tensor) {
+  void AddMapping(std::string name, mlir::Value tensor) {
     assert(onnx_name2onnf_tensor.count(legalize_name(name)) == 0 &&
                         "Tensor already exists.");
     onnx_name2onnf_tensor.emplace(legalize_name(name), tensor);
@@ -97,7 +97,7 @@ private:
   /*!
    *  mapping from onnx tensor names to MLIR tensor.
    */
-  std::map<std::string, mlir::Value*> onnx_name2onnf_tensor;
+  std::map<std::string, mlir::Value> onnx_name2onnf_tensor;
 };
 
 class FrontendGenImpl {
@@ -192,13 +192,13 @@ private:
 
   /*!
    * Import a input tensor symbol by recording a new entry in frontend_symbols_
-   * recording the mapping between legalized onnx tensor name and mlir::Value*
+   * recording the mapping between legalized onnx tensor name and mlir::Value
    * for further lookup in computation node importing.
    * @param input onnx input tensor ValueInfoProto.
    * @param symbol mlir input argument.
    */
   void ImportInputTensorSymbol(const onnx::ValueInfoProto &input,
-                               mlir::Value *symbol) {
+                               mlir::Value symbol) {
     auto input_tensor_legalized_name = legalize_name(input.name());
     assert(
         !frontend_symbols_.ContainKey(input_tensor_legalized_name) &&
@@ -480,7 +480,7 @@ private:
   }
 
   void ImportNodeGeneric(onnx::NodeProto node) {
-    std::vector<mlir::Value *> inputs;
+    std::vector<mlir::Value> inputs;
     for (auto item : node.input()) {
       if (frontend_symbols_.ContainKey(legalize_name(item))) {
         inputs.push_back(frontend_symbols_.GetTensorByOnnxName(item));
@@ -515,7 +515,7 @@ private:
       onnx::NodeProto node, int nIn, int nOut,
       std::initializer_list<std::tuple<std::string, std::string, std::string>>
           attrs) {
-    std::vector<mlir::Value *> inputs;
+    std::vector<mlir::Value> inputs;
     for (auto item : node.input()) {
       if (frontend_symbols_.ContainKey(legalize_name(item))) {
         inputs.push_back(frontend_symbols_.GetTensorByOnnxName(item));
@@ -562,7 +562,7 @@ private:
       onnx::NodeProto node, int nIn, int nOut,
       std::initializer_list<std::tuple<std::string, std::string, std::string>>
           attrs) {
-    std::vector<mlir::Value *> inputs;
+    std::vector<mlir::Value> inputs;
     for (auto item : node.input()) {
       if (frontend_symbols_.ContainKey(legalize_name(item))) {
         inputs.push_back(frontend_symbols_.GetTensorByOnnxName(item));
@@ -633,7 +633,7 @@ private:
   }
 
   void ImportNode(onnx::NodeProto node) {
-    std::vector<mlir::Value *> inputs;
+    std::vector<mlir::Value> inputs;
     for (auto item : node.input()) {
       if (frontend_symbols_.ContainKey(legalize_name(item))) {
         inputs.push_back(frontend_symbols_.GetTensorByOnnxName(item));
@@ -662,17 +662,17 @@ private:
    * Import output tensor, by doing the following:
    * - Add the type of this output tensor to a list of tensor
    *   types representing return types of this graph function.
-   * - Add this output tensor to the list of mlir::Value*
+   * - Add this output tensor to the list of mlir::Value
    *   to be returned by the function representing computation graph.
    * @param output onnx output tensor ValueInfoProto.
    * @param ret_types a vector of tensor types representing graph's
    *   output tensor types.
-   * @param ret_vals a vector of mlir Value* representing graph's
+   * @param ret_vals a vector of mlir Value  representing graph's
    *   output tensor.
    */
   void ImportOutputTensor(const onnx::ValueInfoProto &output,
                           llvm::SmallVectorImpl<mlir::Type> &ret_types,
-                          llvm::SmallVectorImpl<mlir::Value *> &ret_vals) {
+                          llvm::SmallVectorImpl<mlir::Value> &ret_vals) {
     auto output_tensor_legalized_name = legalize_name(output.name());
     assert(
         frontend_symbols_.ContainKey(output_tensor_legalized_name) &&
@@ -722,7 +722,7 @@ private:
     }
 
     llvm::SmallVector<mlir::Type, 4> ret_types;
-    llvm::SmallVector<mlir::Value *, 4> ret_vals;
+    llvm::SmallVector<mlir::Value, 4> ret_vals;
     // Import the output tensors
     for (const auto &output : graph.output()) {
       ImportOutputTensor(output, ret_types, ret_vals);

--- a/src/dialect/krnl/krnl_helper.cpp
+++ b/src/dialect/krnl/krnl_helper.cpp
@@ -9,8 +9,9 @@ namespace onnf {
 
 using namespace mlir;
 
-ParseResult KrnlDialectOperandParser::ParseOptionalOperand(
-    const Type& operandType, Value*& operand) {
+ParseResult
+KrnlDialectOperandParser::ParseOptionalOperand(const Type &operandType,
+                                               Value &operand) {
   // If operand queue is empty, parse more operands and cache them.
   if (_operandRefQueue.empty()) {
     // Parse operand types:
@@ -27,7 +28,7 @@ ParseResult KrnlDialectOperandParser::ParseOptionalOperand(
     auto operand_ref = _operandRefQueue.front();
     _operandRefQueue.pop();
 
-    llvm::SmallVector<Value*, 1> operands;
+    llvm::SmallVector<Value, 1> operands;
     _parser.resolveOperand(operand_ref, operandType, operands);
     operand = operands.front();
     return success();
@@ -38,8 +39,8 @@ ParseResult KrnlDialectOperandParser::ParseOptionalOperand(
 }
 
 ParseResult KrnlDialectOperandParser::ParseOptionalOperand(
-    const Type& operandType, llvm::SmallVectorImpl<Value*>& operandList) {
-  Value* operand = nullptr;
+    const Type &operandType, llvm::SmallVectorImpl<Value> &operandList) {
+  Value operand = nullptr;
   if (ParseOptionalOperand(operandType, operand))
     return failure();
 
@@ -47,8 +48,8 @@ ParseResult KrnlDialectOperandParser::ParseOptionalOperand(
   return success();
 }
 
-ParseResult KrnlDialectOperandParser::ParseOperand(
-    const Type& operandType, Value*& operand) {
+ParseResult KrnlDialectOperandParser::ParseOperand(const Type &operandType,
+                                                   Value &operand) {
   if (ParseOptionalOperand(operandType, operand))
     return _parser.emitError(
         _parser.getCurrentLocation(), "Expecting an operand.");
@@ -56,7 +57,7 @@ ParseResult KrnlDialectOperandParser::ParseOperand(
 }
 
 ParseResult KrnlDialectOperandParser::ParseOperand(
-    const Type& operandType, llvm::SmallVectorImpl<Value*>& operandList) {
+    const Type &operandType, llvm::SmallVectorImpl<Value> &operandList) {
   if (ParseOptionalOperand(operandType, operandList))
     return _parser.emitError(
         _parser.getCurrentLocation(), "Expecting an operand.");
@@ -129,7 +130,7 @@ void KrnlIterateOperandPack::pushConstantBound(int64_t bound) {
   boundMaps.emplace_back(AffineMapAttr::get(map));
 }
 
-void KrnlIterateOperandPack::pushOperandBound(mlir::Value* operand) {
+void KrnlIterateOperandPack::pushOperandBound(mlir::Value operand) {
   if (boundMaps.size() % 2 == 0)
     _operands.emplace_back(inputLoops[boundMaps.size() / 2]);
   AffineMap map = builder.getSymbolIdentityMap();

--- a/src/dialect/krnl/krnl_helper.hpp
+++ b/src/dialect/krnl/krnl_helper.hpp
@@ -17,20 +17,22 @@ class KrnlDialectOperandParser {
       : _parser(parser), _builder(parser.getBuilder()){};
 
   // Parse an optional operand.
-  mlir::ParseResult ParseOptionalOperand(
-      const mlir::Type& operandType, mlir::Value*& operand);
+  mlir::ParseResult ParseOptionalOperand(const mlir::Type &operandType,
+                                         mlir::Value &operand);
 
   // Parse an optional operand and push it to an operand list.
-  mlir::ParseResult ParseOptionalOperand(const mlir::Type& operandType,
-      llvm::SmallVectorImpl<mlir::Value*>& operandList);
+  mlir::ParseResult
+  ParseOptionalOperand(const mlir::Type &operandType,
+                       llvm::SmallVectorImpl<mlir::Value> &operandList);
 
   // Parse a required operand.
-  mlir::ParseResult ParseOperand(
-      const mlir::Type& operandType, mlir::Value*& operand);
+  mlir::ParseResult ParseOperand(const mlir::Type &operandType,
+                                 mlir::Value &operand);
 
   // Parse a required operand and push it to an operand list.
-  mlir::ParseResult ParseOperand(const mlir::Type& operandType,
-      llvm::SmallVectorImpl<mlir::Value*>& operandList);
+  mlir::ParseResult
+  ParseOperand(const mlir::Type &operandType,
+               llvm::SmallVectorImpl<mlir::Value> &operandList);
 
   // Do we have more operands to parse?
   bool hasOperandLeft() { return !_operandRefQueue.empty(); }
@@ -63,11 +65,10 @@ void printBound(mlir::AffineMapAttr boundMap,
 namespace mlir {
 
 struct KrnlIterateOperandPack {
-  KrnlIterateOperandPack(mlir::Builder& builder,
-      llvm::ArrayRef<mlir::Value*> inputLoops,
-      llvm::ArrayRef<mlir::Value*> optimizedLoops)
-      : builder(builder),
-        inputLoops(inputLoops),
+  KrnlIterateOperandPack(mlir::Builder &builder,
+                         llvm::ArrayRef<mlir::Value> inputLoops,
+                         llvm::ArrayRef<mlir::Value> optimizedLoops)
+      : builder(builder), inputLoops(inputLoops),
         optimizedLoops(optimizedLoops) {
     _operands.insert(
         _operands.end(), optimizedLoops.begin(), optimizedLoops.end());
@@ -75,9 +76,9 @@ struct KrnlIterateOperandPack {
 
   void pushConstantBound(int64_t bound);
 
-  void pushOperandBound(mlir::Value* operand);
+  void pushOperandBound(mlir::Value operand);
 
-  llvm::SmallVector<mlir::Value*, 8> getOperands() const { return _operands; }
+  llvm::SmallVector<mlir::Value, 8> getOperands() const { return _operands; }
 
   mlir::ArrayAttr getAttributes() const {
     return builder.getArrayAttr(boundMaps);
@@ -90,11 +91,11 @@ struct KrnlIterateOperandPack {
  private:
   int _boundIdx = 0;
 
-  llvm::SmallVector<mlir::Value*, 8> _operands;
+  llvm::SmallVector<mlir::Value, 8> _operands;
 
   llvm::SmallVector<mlir::Attribute, 8> boundMaps;
 
-  llvm::ArrayRef<mlir::Value*> inputLoops, optimizedLoops;
+  llvm::ArrayRef<mlir::Value> inputLoops, optimizedLoops;
 
   mlir::Builder& builder;
 };

--- a/src/transform/lower_krnl.cpp
+++ b/src/transform/lower_krnl.cpp
@@ -30,7 +30,7 @@ struct KrnlIterateOpLowering : public OpRewritePattern<KrnlIterateOp> {
       operandItr++;
 
       // Organize operands into lower/upper bounds in affine.for ready formats.
-      SmallVector<Value *, 4> lbOperands, ubOperands;
+      SmallVector<Value, 4> lbOperands, ubOperands;
       AffineMap lbMap, ubMap;
       for (int boundType = 0; boundType < 2; boundType++) {
         auto &operands = boundType == 0 ? lbOperands : ubOperands;

--- a/test/mlir/CMakeLists.txt
+++ b/test/mlir/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(LLVM_LIT ${LLVM_SRC}/utils/lit/lit.py)
-set(LLVM_DEFAULT_EXTERNAL_LIT ${LLVM_BUILD}/bin/llvm-lit)
+set(LLVM_LIT ${LLVM_PROJ_SRC}/utils/lit/lit.py)
+set(LLVM_DEFAULT_EXTERNAL_LIT ${LLVM_PROJ_BUILD}/bin/llvm-lit)
 
 configure_lit_site_cfg(${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
                        ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/test/mlir/lit.site.cfg.py.in
+++ b/test/mlir/lit.site.cfg.py.in
@@ -2,7 +2,7 @@
 import lit.llvm
 
 config.llvm_tools_dir = "@MLIR_TOOLS_DIR@"
-config.mlir_obj_root = "@LLVM_BUILD@"
+config.mlir_obj_root = "@LLVM_PROJ_BUILD@"
 config.mlir_tools_dir = "@MLIR_TOOLS_DIR@"
 config.suffixes = ['.mlir']
 


### PR DESCRIPTION
1. mlir::Value used to be passed around by pointer, but MLIR recently moved to pass around mlir::Value by value. Thus I made onnf to pass by value as well.
2. Change env variables used to determine the location of LLVM and MLIR to `LLVM_PROJ_SRC` and `LLVM_PROJ_BUILD`. This change is necessitated by MLIR moving into the llvm-project monorepo.
    - `LLVM_PROJ_SRC` points to the root of llvm-project monorepo.
    - `LLVM_PROJ_BUILD` points to the root of object files built from llvm-project.