### PR TITLE
use boost::variant to import attributes of onnx nodes

### DIFF
--- a/src/builder/op_build_table.inc
+++ b/src/builder/op_build_table.inc
@@ -16,13 +16,13 @@
       });
     }else if (OpName == "ArgMax") {
        ImportNodeOneOut<mlir::ONNXArgMaxOp>(node, 1, 1, {
-         {"axis","int","0"}
-        ,{"keepdims","int","1"}
+         {"axis", 0}
+        ,{"keepdims", 1}
       });
     }else if (OpName == "ArgMin") {
        ImportNodeOneOut<mlir::ONNXArgMinOp>(node, 1, 1, {
-         {"axis","int","0"}
-        ,{"keepdims","int","1"}
+         {"axis", 0}
+        ,{"keepdims", 1}
       });
     }else if (OpName == "Asin") {
        ImportNodeOneOut<mlir::ONNXAsinOp>(node, 1, 1, {
@@ -38,25 +38,22 @@
       });
     }else if (OpName == "AveragePool") {
        ImportNodeOneOut<mlir::ONNXAveragePoolOp>(node, 1, 1, {
-         {"auto_pad","str","NOTSET"}
-        ,{"ceil_mode","int","0"}
-        ,{"count_include_pad","int","0"}
-        ,{"kernel_shape","ints", ""}
-        ,{"pads","", ""}
-        ,{"strides","", ""}
+         {"auto_pad", "NOTSET"}
+        ,{"ceil_mode", 0}
+        ,{"count_include_pad", 0}
+        ,{"kernel_shape", std::vector<int> {}}
       });
     }else if (OpName == "BatchNormalization") {
        ImportNodeMultipleOuts<mlir::ONNXBatchNormalizationOp>(node, 5, 5, {
-         {"epsilon","float","1e-05"}
-        ,{"momentum","float","0.9"}
+         {"epsilon", (float)1e-05}
+        ,{"momentum", (float)0.9}
       });
     }else if (OpName == "BitShift") {
        ImportNodeOneOut<mlir::ONNXBitShiftOp>(node, 2, 1, {
-         {"direction","", ""}
       });
     }else if (OpName == "Cast") {
        ImportNodeOneOut<mlir::ONNXCastOp>(node, 1, 1, {
-         {"to","int", "0"}
+         {"to", 0}
       });
     }else if (OpName == "Ceil") {
        ImportNodeOneOut<mlir::ONNXCeilOp>(node, 1, 1, {
@@ -66,54 +63,35 @@
       });
     }else if (OpName == "Compress") {
        ImportNodeOneOut<mlir::ONNXCompressOp>(node, 2, 1, {
-         {"axis","", ""}
       });
     }else if (OpName == "Concat") {
        ImportNodeOneOut<mlir::ONNXConcatOp>(node, 1, 1, {
-         {"axis","int", "0"}
+         {"axis", 0}
       });
     }else if (OpName == "ConcatFromSequence") {
        ImportNodeOneOut<mlir::ONNXConcatFromSequenceOp>(node, 1, 1, {
-         {"axis","", ""}
-        ,{"new_axis","int","0"}
+         {"new_axis", 0}
       });
     }else if (OpName == "Constant") {
        ImportNodeOneOut<mlir::ONNXConstantOp>(node, 0, 1, {
-         {"sparse_value","", ""}
-        ,{"value","", ""}
       });
     }else if (OpName == "ConstantOfShape") {
        ImportNodeOneOut<mlir::ONNXConstantOfShapeOp>(node, 1, 1, {
-         {"value","", ""}
       });
     }else if (OpName == "Conv") {
        ImportNodeConv(node, 3, 1, {
-         {"auto_pad","str","NOTSET"}
-        ,{"dilations","", ""}
-        ,{"group","int", "1"}
-        ,{"kernel_shape","", ""}
-        ,{"pads","", ""}
-        ,{"strides","", ""}
+         {"auto_pad", "NOTSET"}
+        ,{"group", 1}
       });
     }else if (OpName == "ConvInteger") {
        ImportNodeOneOut<mlir::ONNXConvIntegerOp>(node, 4, 1, {
-         {"auto_pad","str","NOTSET"}
-        ,{"dilations","", ""}
-        ,{"group","int","1"}
-        ,{"kernel_shape","", ""}
-        ,{"pads","", ""}
-        ,{"strides","", ""}
+         {"auto_pad", "NOTSET"}
+        ,{"group", 1}
       });
     }else if (OpName == "ConvTranspose") {
        ImportNodeOneOut<mlir::ONNXConvTransposeOp>(node, 3, 1, {
-         {"auto_pad","str","NOTSET"}
-        ,{"dilations","", ""}
-        ,{"group","int","1"}
-        ,{"kernel_shape","", ""}
-        ,{"output_padding","", ""}
-        ,{"output_shape","", ""}
-        ,{"pads","", ""}
-        ,{"strides","", ""}
+         {"auto_pad", "NOTSET"}
+        ,{"group", 1}
       });
     }else if (OpName == "Cos") {
        ImportNodeOneOut<mlir::ONNXCosOp>(node, 1, 1, {
@@ -123,13 +101,12 @@
       });
     }else if (OpName == "CumSum") {
        ImportNodeOneOut<mlir::ONNXCumSumOp>(node, 2, 1, {
-         {"exclusive","int","0"}
-        ,{"reverse","int","0"}
+         {"exclusive", 0}
+        ,{"reverse", 0}
       });
     }else if (OpName == "DepthToSpace") {
        ImportNodeOneOut<mlir::ONNXDepthToSpaceOp>(node, 1, 1, {
-         {"blocksize","", ""}
-        ,{"mode","str","DCR"}
+         {"mode", "DCR"}
       });
     }else if (OpName == "DequantizeLinear") {
        ImportNodeOneOut<mlir::ONNXDequantizeLinearOp>(node, 3, 1, {
@@ -142,14 +119,14 @@
       });
     }else if (OpName == "Dropout") {
        ImportNodeMultipleOuts<mlir::ONNXDropoutOp>(node, 1, 2, {
-         {"ratio","float","0.5"}
+         {"ratio", (float)0.5}
       });
     }else if (OpName == "DynamicQuantizeLinear") {
        ImportNodeMultipleOuts<mlir::ONNXDynamicQuantizeLinearOp>(node, 1, 3, {
       });
     }else if (OpName == "Elu") {
        ImportNodeOneOut<mlir::ONNXEluOp>(node, 1, 1, {
-         {"alpha","float","1.0"}
+         {"alpha", (float)1.0}
       });
     }else if (OpName == "Equal") {
        ImportNodeOneOut<mlir::ONNXEqualOp>(node, 2, 1, {
@@ -165,50 +142,44 @@
       });
     }else if (OpName == "EyeLike") {
        ImportNodeOneOut<mlir::ONNXEyeLikeOp>(node, 1, 1, {
-         {"dtype","", ""}
-        ,{"k","int","0"}
+         {"k", 0}
       });
     }else if (OpName == "Flatten") {
        ImportNodeOneOut<mlir::ONNXFlattenOp>(node, 1, 1, {
-         {"axis","int","1"}
+         {"axis", 1}
       });
     }else if (OpName == "Floor") {
        ImportNodeOneOut<mlir::ONNXFloorOp>(node, 1, 1, {
       });
     }else if (OpName == "GRU") {
        ImportNodeMultipleOuts<mlir::ONNXGRUOp>(node, 6, 2, {
-         {"activation_alpha","", ""}
-        ,{"activation_beta","", ""}
-        ,{"activations","", ""}
-        ,{"clip","", ""}
-        ,{"direction","str","forward"}
-        ,{"hidden_size","", ""}
-        ,{"linear_before_reset","int","0"}
+         {"direction", "forward"}
+        ,{"linear_before_reset", 0}
       });
     }else if (OpName == "Gather") {
        ImportNodeOneOut<mlir::ONNXGatherOp>(node, 2, 1, {
-         {"axis","int","0"}
+         {"axis", 0}
       });
     }else if (OpName == "GatherElements") {
        ImportNodeOneOut<mlir::ONNXGatherElementsOp>(node, 2, 1, {
-         {"axis","int","0"}
+         {"axis", 0}
       });
     }else if (OpName == "GatherND") {
        ImportNodeOneOut<mlir::ONNXGatherNDOp>(node, 2, 1, {
       });
     }else if (OpName == "Gemm") {
        ImportNodeOneOut<mlir::ONNXGemmOp>(node, 3, 1, {
-         {"alpha","float","1.0"}
-        ,{"beta","float","1.0"}
-        ,{"transA","int","0"}
-        ,{"transB","int","0"}
+         {"alpha", (float)1.0}
+        ,{"beta", (float)1.0}
+        ,{"transA", 0}
+        ,{"transB", 0}
       });
     }else if (OpName == "GlobalAveragePool") {
        ImportNodeOneOut<mlir::ONNXGlobalAveragePoolOp>(node, 1, 1, {
       });
     }else if (OpName == "GlobalLpPool") {
        ImportNodeOneOut<mlir::ONNXGlobalLpPoolOp>(node, 1, 1, {
-         {"p","int","2"}
+         {"p", 2}
       });
     }else if (OpName == "GlobalMaxPool") {
        ImportNodeOneOut<mlir::ONNXGlobalMaxPoolOp>(node, 1, 1, {
@@ -218,53 +189,45 @@
       });
     }else if (OpName == "HardSigmoid") {
        ImportNodeOneOut<mlir::ONNXHardSigmoidOp>(node, 1, 1, {
-         {"alpha","float","0.2"}
-        ,{"beta","float","0.5"}
+         {"alpha", (float)0.2}
+        ,{"beta", (float)0.5}
       });
     }else if (OpName == "Hardmax") {
        ImportNodeOneOut<mlir::ONNXHardmaxOp>(node, 1, 1, {
-         {"axis","int","1"}
+         {"axis", 1}
       });
     }else if (OpName == "Identity") {
        ImportNodeOneOut<mlir::ONNXIdentityOp>(node, 1, 1, {
       });
     }else if (OpName == "If") {
        ImportNodeOneOut<mlir::ONNXIfOp>(node, 1, 1, {
-         {"else_branch","", ""}
-        ,{"then_branch","", ""}
       });
     }else if (OpName == "InstanceNormalization") {
        ImportNodeOneOut<mlir::ONNXInstanceNormalizationOp>(node, 3, 1, {
-         {"epsilon","float","1e-05"}
+         {"epsilon", (float)1e-05}
       });
     }else if (OpName == "IsInf") {
        ImportNodeOneOut<mlir::ONNXIsInfOp>(node, 1, 1, {
-         {"detect_negative","int","1"}
-        ,{"detect_positive","int","1"}
+         {"detect_negative", 1}
+        ,{"detect_positive", 1}
       });
     }else if (OpName == "IsNaN") {
        ImportNodeOneOut<mlir::ONNXIsNaNOp>(node, 1, 1, {
       });
     }else if (OpName == "LRN") {
        ImportNodeOneOut<mlir::ONNXLRNOp>(node, 1, 1, {
-         {"alpha","float","0.0001"}
-        ,{"beta","float","0.75"}
-        ,{"bias","float","1.0"}
-        ,{"size","int", ""}
+         {"alpha", (float)0.0001}
+        ,{"beta", (float)0.75}
+        ,{"bias", (float)1.0}
       });
     }else if (OpName == "LSTM") {
        ImportNodeMultipleOuts<mlir::ONNXLSTMOp>(node, 8, 3, {
-         {"activation_alpha","", ""}
-        ,{"activation_beta","", ""}
-        ,{"activations","", ""}
-        ,{"clip","", ""}
-        ,{"direction","str","forward"}
-        ,{"hidden_size","", ""}
-        ,{"input_forget","int","0"}
+         {"direction", "forward"}
+        ,{"input_forget", 0}
       });
     }else if (OpName == "LeakyRelu") {
        ImportNodeOneOut<mlir::ONNXLeakyReluOp>(node, 1, 1, {
-         {"alpha","float","0.01"}
+         {"alpha", (float)0.01}
       });
     }else if (OpName == "Less") {
        ImportNodeOneOut<mlir::ONNXLessOp>(node, 2, 1, {
@@ -274,24 +237,20 @@
       });
     }else if (OpName == "LogSoftmax") {
        ImportNodeOneOut<mlir::ONNXLogSoftmaxOp>(node, 1, 1, {
-         {"axis","int","1"}
+         {"axis", 1}
       });
     }else if (OpName == "Loop") {
        ImportNodeOneOut<mlir::ONNXLoopOp>(node, 3, 1, {
-         {"body","", ""}
       });
     }else if (OpName == "LpNormalization") {
        ImportNodeOneOut<mlir::ONNXLpNormalizationOp>(node, 1, 1, {
-         {"axis","int","-1"}
-        ,{"p","int","2"}
+         {"axis", -1}
+        ,{"p", 2}
       });
     }else if (OpName == "LpPool") {
        ImportNodeOneOut<mlir::ONNXLpPoolOp>(node, 1, 1, {
-         {"auto_pad","str","NOTSET"}
-        ,{"kernel_shape","", ""}
-        ,{"p","int","2"}
-        ,{"pads","", ""}
-        ,{"strides","", ""}
+         {"auto_pad", "NOTSET"}
+        ,{"p", 2}
       });
     }else if (OpName == "MatMul") {
        ImportNodeOneOut<mlir::ONNXMatMulOp>(node, 2, 1, {
@@ -304,54 +263,46 @@
       });
     }else if (OpName == "MaxPool") {
        ImportNodeMultipleOuts<mlir::ONNXMaxPoolOp>(node, 1, 2, {
-         {"auto_pad","str","NOTSET"}
-        ,{"ceil_mode","int","0"}
-        ,{"dilations","", ""}
-        ,{"kernel_shape","ints", ""}
-        ,{"pads","", ""}
-        ,{"storage_order","int","0"}
-        ,{"strides","", ""}
+         {"auto_pad", "NOTSET"}
+        ,{"ceil_mode", 0}
+        ,{"kernel_shape", std::vector<int> {}}
+        ,{"storage_order", 0}
       });
     }else if (OpName == "MaxRoiPool") {
        ImportNodeOneOut<mlir::ONNXMaxRoiPoolOp>(node, 2, 1, {
-         {"pooled_shape","", ""}
-        ,{"spatial_scale","float","1.0"}
+         {"spatial_scale", (float)1.0}
       });
     }else if (OpName == "MaxUnpool") {
        ImportNodeOneOut<mlir::ONNXMaxUnpoolOp>(node, 3, 1, {
-         {"kernel_shape","", ""}
-        ,{"pads","", ""}
-        ,{"strides","", ""}
       });
     }else if (OpName == "Mean") {
        ImportNodeOneOut<mlir::ONNXMeanOp>(node, 1, 1, {
       });
     }else if (OpName == "MeanVarianceNormalization") {
        ImportNodeOneOut<mlir::ONNXMeanVarianceNormalizationOp>(node, 1, 1, {
-         {"axes","ints","{'0', '2', '3'}"}
+         {"axes", std::vector<int>{0, 2, 3}}
       });
     }else if (OpName == "Min") {
        ImportNodeOneOut<mlir::ONNXMinOp>(node, 1, 1, {
       });
     }else if (OpName == "Mod") {
        ImportNodeOneOut<mlir::ONNXModOp>(node, 2, 1, {
-         {"fmod","int","0"}
+         {"fmod", 0}
       });
     }else if (OpName == "Mul") {
        ImportNodeOneOut<mlir::ONNXMulOp>(node, 2, 1, {
       });
     }else if (OpName == "Multinomial") {
        ImportNodeOneOut<mlir::ONNXMultinomialOp>(node, 1, 1, {
-         {"dtype","int","6"}
-        ,{"sample_size","int","1"}
-        ,{"seed","", ""}
+         {"dtype", 6}
+        ,{"sample_size", 1}
       });
     }else if (OpName == "Neg") {
        ImportNodeOneOut<mlir::ONNXNegOp>(node, 1, 1, {
       });
     }else if (OpName == "NonMaxSuppression") {
        ImportNodeOneOut<mlir::ONNXNonMaxSuppressionOp>(node, 5, 1, {
-         {"center_point_box","int","0"}
+         {"center_point_box", 0}
       });
     }else if (OpName == "NonZero") {
        ImportNodeOneOut<mlir::ONNXNonZeroOp>(node, 1, 1, {
@@ -361,7 +312,7 @@
       });
     }else if (OpName == "OneHot") {
        ImportNodeOneOut<mlir::ONNXOneHotOp>(node, 3, 1, {
-         {"axis","int","-1"}
+         {"axis", -1}
       });
     }else if (OpName == "Or") {
        ImportNodeOneOut<mlir::ONNXOrOp>(node, 2, 1, {
@@ -371,19 +322,15 @@
       });
     }else if (OpName == "Pad") {
        ImportNodeOneOut<mlir::ONNXPadOp>(node, 3, 1, {
-         {"mode","str","constant"}
+         {"mode", "constant"}
       });
     }else if (OpName == "Pow") {
        ImportNodeOneOut<mlir::ONNXPowOp>(node, 2, 1, {
       });
     }else if (OpName == "QLinearConv") {
        ImportNodeOneOut<mlir::ONNXQLinearConvOp>(node, 9, 1, {
-         {"auto_pad","str","NOTSET"}
-        ,{"dilations","", ""}
-        ,{"group","int","1"}
-        ,{"kernel_shape","", ""}
-        ,{"pads","", ""}
-        ,{"strides","", ""}
+         {"auto_pad", "NOTSET"}
+        ,{"group", 1}
       });
     }else if (OpName == "QLinearMatMul") {
        ImportNodeOneOut<mlir::ONNXQLinearMatMulOp>(node, 8, 1, {
@@ -393,42 +340,32 @@
       });
     }else if (OpName == "RNN") {
        ImportNodeMultipleOuts<mlir::ONNXRNNOp>(node, 6, 2, {
-         {"activation_alpha","floats", "{}"}
-        ,{"activation_beta","floats", "{}"}
-        ,{"activations","", "{Tannh, Tanh}"}
-        ,{"clip","", ""}
-        ,{"direction","str","forward"}
-        ,{"hidden_size","", ""}
+         {"activation_alpha", std::vector<float> {}}
+        ,{"activation_beta", std::vector<float> {}}
+        ,{"activations", std::vector<std::string>{"Tanh", "Tanh"}}
+        ,{"direction", "forward"}
       });
     }else if (OpName == "RandomNormal") {
        ImportNodeOneOut<mlir::ONNXRandomNormalOp>(node, 0, 1, {
-         {"dtype","int","1"}
-        ,{"mean","float","0.0"}
-        ,{"scale","float","1.0"}
-        ,{"seed","", ""}
-        ,{"shape","", ""}
+         {"dtype", 1}
+        ,{"mean", (float)0.0}
+        ,{"scale", (float)1.0}
       });
     }else if (OpName == "RandomNormalLike") {
        ImportNodeOneOut<mlir::ONNXRandomNormalLikeOp>(node, 1, 1, {
-         {"dtype","", ""}
-        ,{"mean","float","0.0"}
-        ,{"scale","float","1.0"}
-        ,{"seed","", ""}
+         {"mean", (float)0.0}
+        ,{"scale", (float)1.0}
       });
     }else if (OpName == "RandomUniform") {
        ImportNodeOneOut<mlir::ONNXRandomUniformOp>(node, 0, 1, {
-         {"dtype","int","1"}
-        ,{"high","float","1.0"}
-        ,{"low","float","0.0"}
-        ,{"seed","", ""}
-        ,{"shape","", ""}
+         {"dtype", 1}
+        ,{"high", (float)1.0}
+        ,{"low", (float)0.0}
       });
     }else if (OpName == "RandomUniformLike") {
        ImportNodeOneOut<mlir::ONNXRandomUniformLikeOp>(node, 1, 1, {
-         {"dtype","", ""}
-        ,{"high","float","1.0"}
-        ,{"low","float","0.0"}
-        ,{"seed","", ""}
+         {"high", (float)1.0}
+        ,{"low", (float)0.0}
       });
     }else if (OpName == "Range") {
        ImportNodeOneOut<mlir::ONNXRangeOp>(node, 3, 1, {
@@ -438,53 +375,43 @@
       });
     }else if (OpName == "ReduceL1") {
        ImportNodeOneOut<mlir::ONNXReduceL1Op>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceL2") {
        ImportNodeOneOut<mlir::ONNXReduceL2Op>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceLogSum") {
        ImportNodeOneOut<mlir::ONNXReduceLogSumOp>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceLogSumExp") {
        ImportNodeOneOut<mlir::ONNXReduceLogSumExpOp>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceMax") {
        ImportNodeOneOut<mlir::ONNXReduceMaxOp>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceMean") {
        ImportNodeOneOut<mlir::ONNXReduceMeanOp>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceMin") {
        ImportNodeOneOut<mlir::ONNXReduceMinOp>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceProd") {
        ImportNodeOneOut<mlir::ONNXReduceProdOp>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceSum") {
        ImportNodeOneOut<mlir::ONNXReduceSumOp>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "ReduceSumSquare") {
        ImportNodeOneOut<mlir::ONNXReduceSumSquareOp>(node, 1, 1, {
-         {"axes","", ""}
-        ,{"keepdims","int","1"}
+         {"keepdims", 1}
       });
     }else if (OpName == "Relu") {
        ImportNodeOneOut<mlir::ONNXReluOp>(node, 1, 1, {
@@ -494,53 +421,47 @@
       });
     }else if (OpName == "Resize") {
        ImportNodeOneOut<mlir::ONNXResizeOp>(node, 4, 1, {
-         {"coordinate_transformation_mode","str","half_pixel"}
-        ,{"cubic_coeff_a","float","-0.75"}
-        ,{"exclude_outside","int","0"}
-        ,{"extrapolation_value","float","0.0"}
-        ,{"mode","str","nearest"}
-        ,{"nearest_mode","str","round_prefer_floor"}
+         {"coordinate_transformation_mode", "half_pixel"}
+        ,{"cubic_coeff_a", (float)-0.75}
+        ,{"exclude_outside", 0}
+        ,{"extrapolation_value", (float)0.0}
+        ,{"mode", "nearest"}
+        ,{"nearest_mode", "round_prefer_floor"}
       });
     }else if (OpName == "ReverseSequence") {
        ImportNodeOneOut<mlir::ONNXReverseSequenceOp>(node, 2, 1, {
-         {"batch_axis","int","1"}
-        ,{"time_axis","int","0"}
+         {"batch_axis", 1}
+        ,{"time_axis", 0}
       });
     }else if (OpName == "RoiAlign") {
        ImportNodeOneOut<mlir::ONNXRoiAlignOp>(node, 3, 1, {
-         {"mode","str","avg"}
-        ,{"output_height","int","1"}
-        ,{"output_width","int","1"}
-        ,{"sampling_ratio","int","0"}
-        ,{"spatial_scale","float","1.0"}
+         {"mode", "avg"}
+        ,{"output_height", 1}
+        ,{"output_width", 1}
+        ,{"sampling_ratio", 0}
+        ,{"spatial_scale", (float)1.0}
       });
     }else if (OpName == "Round") {
        ImportNodeOneOut<mlir::ONNXRoundOp>(node, 1, 1, {
       });
     }else if (OpName == "Scan") {
        ImportNodeOneOut<mlir::ONNXScanOp>(node, 1, 1, {
-         {"body","", ""}
-        ,{"num_scan_inputs","", ""}
-        ,{"scan_input_axes","", ""}
-        ,{"scan_input_directions","", ""}
-        ,{"scan_output_axes","", ""}
-        ,{"scan_output_directions","", ""}
       });
     }else if (OpName == "Scatter") {
        ImportNodeOneOut<mlir::ONNXScatterOp>(node, 3, 1, {
-         {"axis","int","0"}
+         {"axis", 0}
       });
     }else if (OpName == "ScatterElements") {
        ImportNodeOneOut<mlir::ONNXScatterElementsOp>(node, 3, 1, {
-         {"axis","int","0"}
+         {"axis", 0}
       });
     }else if (OpName == "ScatterND") {
        ImportNodeOneOut<mlir::ONNXScatterNDOp>(node, 3, 1, {
       });
     }else if (OpName == "Selu") {
        ImportNodeOneOut<mlir::ONNXSeluOp>(node, 1, 1, {
-         {"alpha","float","1.67326"}
-        ,{"gamma","float","1.0507"}
+         {"alpha", (float)1.67326}
+        ,{"gamma", (float)1.0507}
       });
     }else if (OpName == "SequenceAt") {
        ImportNodeOneOut<mlir::ONNXSequenceAtOp>(node, 2, 1, {
@@ -550,7 +471,6 @@
       });
     }else if (OpName == "SequenceEmpty") {
        ImportNodeOneOut<mlir::ONNXSequenceEmptyOp>(node, 0, 1, {
-         {"dtype","", ""}
       });
     }else if (OpName == "SequenceErase") {
        ImportNodeOneOut<mlir::ONNXSequenceEraseOp>(node, 2, 1, {
@@ -566,8 +486,8 @@
       });
     }else if (OpName == "Shrink") {
        ImportNodeOneOut<mlir::ONNXShrinkOp>(node, 1, 1, {
-         {"bias","float","0.0"}
-        ,{"lambd","float","0.5"}
+         {"bias", (float)0.0}
+        ,{"lambd", (float)0.5}
       });
     }else if (OpName == "Sigmoid") {
        ImportNodeOneOut<mlir::ONNXSigmoidOp>(node, 1, 1, {
@@ -589,7 +509,7 @@
       });
     }else if (OpName == "Softmax") {
        ImportNodeOneOut<mlir::ONNXSoftmaxOp>(node, 1, 1, {
-         {"axis","int","1"}
+         {"axis", 1}
       });
     }else if (OpName == "Softplus") {
        ImportNodeOneOut<mlir::ONNXSoftplusOp>(node, 1, 1, {
@@ -599,31 +519,26 @@
       });
     }else if (OpName == "SpaceToDepth") {
        ImportNodeOneOut<mlir::ONNXSpaceToDepthOp>(node, 1, 1, {
-         {"blocksize","", ""}
       });
     }else if (OpName == "Split") {
        ImportNodeOneOut<mlir::ONNXSplitOp>(node, 1, 1, {
-         {"axis","int","0"}
-        ,{"split","", ""}
+         {"axis", 0}
       });
     }else if (OpName == "SplitToSequence") {
        ImportNodeOneOut<mlir::ONNXSplitToSequenceOp>(node, 2, 1, {
-         {"axis","int","0"}
-        ,{"keepdims","int","1"}
+         {"axis", 0}
+        ,{"keepdims", 1}
       });
     }else if (OpName == "Sqrt") {
        ImportNodeOneOut<mlir::ONNXSqrtOp>(node, 1, 1, {
       });
     }else if (OpName == "Squeeze") {
        ImportNodeOneOut<mlir::ONNXSqueezeOp>(node, 1, 1, {
-         {"axes","", ""}
       });
     }else if (OpName == "StringNormalizer") {
        ImportNodeOneOut<mlir::ONNXStringNormalizerOp>(node, 1, 1, {
-         {"case_change_action","str","NONE"}
-        ,{"is_case_sensitive","int","0"}
-        ,{"locale","", ""}
-        ,{"stopwords","", ""}
+         {"case_change_action", "NONE"}
+        ,{"is_case_sensitive", 0}
       });
     }else if (OpName == "Sub") {
        ImportNodeOneOut<mlir::ONNXSubOp>(node, 2, 1, {
@@ -639,45 +554,34 @@
       });
     }else if (OpName == "TfIdfVectorizer") {
        ImportNodeOneOut<mlir::ONNXTfIdfVectorizerOp>(node, 1, 1, {
-         {"max_gram_length","", ""}
-        ,{"max_skip_count","", ""}
-        ,{"min_gram_length","", ""}
-        ,{"mode","", ""}
-        ,{"ngram_counts","", ""}
-        ,{"ngram_indexes","", ""}
-        ,{"pool_int64s","", ""}
-        ,{"pool_strings","", ""}
-        ,{"weights","", ""}
       });
     }else if (OpName == "ThresholdedRelu") {
        ImportNodeOneOut<mlir::ONNXThresholdedReluOp>(node, 1, 1, {
-         {"alpha","float","1.0"}
+         {"alpha", (float)1.0}
       });
     }else if (OpName == "Tile") {
        ImportNodeOneOut<mlir::ONNXTileOp>(node, 2, 1, {
       });
     }else if (OpName == "TopK") {
        ImportNodeMultipleOuts<mlir::ONNXTopKOp>(node, 2, 2, {
-         {"axis","int","-1"}
-        ,{"largest","int","1"}
-        ,{"sorted","int","1"}
+         {"axis", -1}
+        ,{"largest", 1}
+        ,{"sorted", 1}
       });
     }else if (OpName == "Transpose") {
        ImportNodeOneOut<mlir::ONNXTransposeOp>(node, 1, 1, {
-         {"perm","", ""}
       });
     }else if (OpName == "Unique") {
        ImportNodeMultipleOuts<mlir::ONNXUniqueOp>(node, 1, 4, {
-         {"axis","", ""}
-        ,{"sorted","int","1"}
+         {"sorted", 1}
       });
     }else if (OpName == "Unsqueeze") {
        ImportNodeOneOut<mlir::ONNXUnsqueezeOp>(node, 1, 1, {
-         {"axes","ints", ""}
+         {"axes", std::vector<int> {}}
       });
     }else if (OpName == "Upsample") {
        ImportNodeOneOut<mlir::ONNXUpsampleOp>(node, 2, 1, {
-         {"mode","str","nearest"}
+         {"mode", "nearest"}
       });
     }else if (OpName == "Where") {
        ImportNodeOneOut<mlir::ONNXWhereOp>(node, 3, 1, {

--- a/src/dialect/onnx/gen_doc.py
+++ b/src/dialect/onnx/gen_doc.py
@@ -367,17 +367,17 @@ def gen_code(schema,fefile) :
         ("Conv", "ImportNodeConv"),
         #("Transpose", "ImportNodeTranspose")
         ])
-    special_type = dict([
-        ("AveragePool "+"kernel_shape", '"ints", ""'),
-        ("MaxPool "+"kernel_shape", '"ints", ""'),
-        ("Cast "+"to", '"int", "0"'),
-        ("Concat "+"axis", '"int", "0"'),
-        ("Conv "+"group", '"int", "1"'),
-        ("Unsqueeze "+"axes", '"ints", ""'),
-        ("RNN "+"activation_alpha", '"floats", "{}"'),
-        ("RNN "+"activation_beta", '"floats", "{}"'),
-        ("RNN "+"activations", '"", "{Tannh, Tanh}"'),
-        ("LRN "+"size", '"int", ""')
+    list_str = 'std::vector'
+    empty_ints = list_str+'<int> {}' 
+    empty_floats = list_str+'<float> {}' 
+    special_default = dict([
+        ("AveragePool "+"kernel_shape", empty_ints),
+        ("MaxPool "+"kernel_shape", empty_ints),
+        ("Cast "+"to", '0'),
+        ("Concat "+"axis", '0'),
+        ("Unsqueeze "+"axes", empty_ints),
+        ("RNN "+"activation_alpha", empty_floats),
+        ("RNN "+"activation_beta", empty_floats)
         ])
     line_indent = '  '
     fefile.write('    '+'}else if (OpName == "'+schema.name+'") {\n')
@@ -399,21 +399,9 @@ def gen_code(schema,fefile) :
     if schema.attributes:
         first_attr = True
         for _, attr in sorted(schema.attributes.items()):
-            attr_line = line_indent+line_indent+line_indent+line_indent
-            if not first_attr:
-                attr_line += ',{'
-            else :
-                attr_line += ' {'
-            first_attr = False
-
-            attr_line += '"'+attr.name+'",'
-
-            if schema.name+' '+attr.name in special_type:
-                attr_line += special_type[schema.name+' '+attr.name]
-            # option holds either required or default value
-            elif attr.required:
-                attr_line += '"", ""'
-      
+            #only generate default attr list
+            if schema.name+' '+attr.name in special_default:
+                attr_value = special_default[schema.name+' '+attr.name]
             elif attr.default_value.name:
                 default_value = helper.get_attribute_value(attr.default_value)
 
@@ -429,28 +417,35 @@ def gen_code(schema,fefile) :
                     return str(value)
 
                 if isinstance(default_value, list):
+
                     value = default_value[0]
                     default_value = [format_value(val) for val in default_value]
+                    attr_option_str = '{}'.format(default_value)
+                    attr_option_str = attr_option_str.replace('[', '{', 1)
+                    attr_option_str = attr_option_str.replace(']', '}', 1)
                     # TODO the list type is homogenous or htergeneous?
                    
                     if isinstance(value, float) : 
-                        attr_type_str = '"floats"'
+                        attr_type_str = list_str+'<float>'
+                        attr_option_str = attr_option_str.replace("'", '')
                     elif isinstance(value, int) :
-                        attr_type_str = '"ints"'
+                        attr_type_str = list_str+'<int>'
+                        attr_option_str = attr_option_str.replace("'", '')
                     elif isinstance(value, str) :
-                        attr_type_str = '"strs"'
+                        attr_type_str = list_str+'<std::string>'
+                        attr_option_str = attr_option_str.replace("'", '"')
                     elif isinstance(value, (bytes, bytearray)) :
-                        attr_type_str = '"strs"'
+                        attr_type_str = list_str+'<std::string>'
+                        attr_option_str = attr_option_str.replace("'", '"')
                     else :
                         attr_type_str = '"unknowns"'
-                    attr_option_str = '"{}"'.format(default_value)
-                    attr_option_str = attr_option_str.replace('[', '{', 1)
-                    attr_option_str = attr_option_str.replace(']', '}', 1)
                 else:
                     if isinstance(default_value, float) : 
-                        attr_type_str = '"float"'
+                        attr_type_str = '(float)'
+                        attr_option_str = default_value
                     elif isinstance(default_value, int) :
-                        attr_type_str = '"int"'
+                        attr_option_str = default_value
+                        attr_type_str=''
                     elif isinstance(default_value, str) :
                         attr_type_str = '"str"'
                     elif isinstance(default_value, (bytes, bytearray)) :
@@ -458,11 +453,25 @@ def gen_code(schema,fefile) :
                     else :
                         attr_type_str = '"unknown"'
                     default_value = format_value(default_value)
-                    attr_option_str = '"{}"'.format(default_value)
-                attr_line += attr_type_str+','+attr_option_str
+                    if attr_type_str == '"str"' :
+                        attr_option_str = '"'+default_value+'"'
+                        attr_type_str=''
+                    else :
+                        attr_option_str = default_value
+                attr_value = attr_type_str+attr_option_str
             else:
-                #TODO why?
-                attr_line += '"", ""'
+                #no default value
+                continue
+
+            attr_line = line_indent+line_indent+line_indent+line_indent
+            if not first_attr:
+                attr_line += ',{'
+            else :
+                attr_line += ' {'
+            first_attr = False
+
+            attr_line += '"'+attr.name+'", '
+            attr_line += attr_value
             attr_line += '}\n'
             fefile.write(attr_line)
     fefile.write(line_indent+line_indent+line_indent+'});\n')


### PR DESCRIPTION
1. design change:
First import all the attributes specified for a node purely based on the info carried by onnx node
second import the default attributes that have no been specified for this node. The default attribute list is generated by gen_doc.py
2. implementation change:
variant is used to represent different type of value. converter from string is avoided.
3. future work
   * some types for attribute in onnx document are not supported yet
   * should build a table of function for each operation. The table initialization will be generated from the script. I feel the code is neater in such a way. Also, more efficient if we add some common code for each onnx operation.
   * our script to generate code should be separated from gen_doc.py