### PR TITLE
Use a more compatible way to locate python interpreter executable.

### DIFF
--- a/doc/doc_check/CMakeLists.txt
+++ b/doc/doc_check/CMakeLists.txt
@@ -1,8 +1,7 @@
-find_package(Python3 REQUIRED
-             COMPONENTS Interpreter)
+find_package(PythonInterp 3 REQUIRED)
 
 add_custom_target(check-doc
-        COMMAND Python3::Interpreter
+        COMMAND ${PYTHON_EXECUTABLE}
                     ${CMAKE_CURRENT_SOURCE_DIR}/check.py
                         ${CMAKE_SOURCE_DIR}
                         --exclude_dirs third_party doc/doc_check/test)


### PR DESCRIPTION
@tungld @imaihal
Does this patch look like a reasonable alternative to find python interpreter? 
