### PR TITLE
Change the type of vector attributes in gen_doc.py

### DIFF
--- a/src/builder/op_build_table.inc
+++ b/src/builder/op_build_table.inc
@@ -18,11 +18,13 @@
        ImportNodeOneOut<mlir::ONNXArgMaxOp>(node, 1, 1, {
          {"axis", 0}
         ,{"keepdims", 1}
+        ,{"select_last_index", 0}
       });
     }else if (OpName == "ArgMin") {
        ImportNodeOneOut<mlir::ONNXArgMinOp>(node, 1, 1, {
          {"axis", 0}
         ,{"keepdims", 1}
+        ,{"select_last_index", 0}
       });
     }else if (OpName == "Asin") {
        ImportNodeOneOut<mlir::ONNXAsinOp>(node, 1, 1, {

--- a/src/dialect/onnx/gen_doc.py
+++ b/src/dialect/onnx/gen_doc.py
@@ -369,7 +369,7 @@ def gen_code(schema,fefile) :
         #("Transpose", "ImportNodeTranspose")
         ])
     list_str = 'std::vector'
-    empty_ints = list_str+'<int> {}' 
+    empty_ints = list_str+'<int64_t> {}'
     empty_floats = list_str+'<float> {}' 
     special_default = dict([
         ("AveragePool "+"kernel_shape", empty_ints),
@@ -430,7 +430,7 @@ def gen_code(schema,fefile) :
                         attr_type_str = list_str+'<float>'
                         attr_option_str = attr_option_str.replace("'", '')
                     elif isinstance(value, int) :
-                        attr_type_str = list_str+'<int>'
+                        attr_type_str = list_str+'<int64_t>'
                         attr_option_str = attr_option_str.replace("'", '')
                     elif isinstance(value, str) :
                         attr_type_str = list_str+'<std::string>'


### PR DESCRIPTION
It seems someone manually edited `op_build_table.inc` for changing vector attribute's type from `vector<int>` to `vector<int64_t>`, while it is still `vector<int>` in the script `gen_doc.py`. This patch is to update `gen_doc.py` for this change.