### PR TITLE
Add attributes as operation parameters

### DIFF
--- a/src/builder/op_build_table.inc
+++ b/src/builder/op_build_table.inc
@@ -1,592 +1,314 @@
     if (OpName == "DUMMY") {
     }else if (OpName == "Abs") {
-       ImportNodeOneOut<mlir::ONNXAbsOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAbsOp>(node, 1, 1);
     }else if (OpName == "Acos") {
-       ImportNodeOneOut<mlir::ONNXAcosOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAcosOp>(node, 1, 1);
     }else if (OpName == "Acosh") {
-       ImportNodeOneOut<mlir::ONNXAcoshOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAcoshOp>(node, 1, 1);
     }else if (OpName == "Add") {
-       ImportNodeOneOut<mlir::ONNXAddOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAddOp>(node, 2, 1);
     }else if (OpName == "And") {
-       ImportNodeOneOut<mlir::ONNXAndOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAndOp>(node, 2, 1);
     }else if (OpName == "ArgMax") {
-       ImportNodeOneOut<mlir::ONNXArgMaxOp>(node, 1, 1, {
-         {"axis", 0}
-        ,{"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXArgMaxOp>(node, 1, 1);
     }else if (OpName == "ArgMin") {
-       ImportNodeOneOut<mlir::ONNXArgMinOp>(node, 1, 1, {
-         {"axis", 0}
-        ,{"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXArgMinOp>(node, 1, 1);
     }else if (OpName == "Asin") {
-       ImportNodeOneOut<mlir::ONNXAsinOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAsinOp>(node, 1, 1);
     }else if (OpName == "Asinh") {
-       ImportNodeOneOut<mlir::ONNXAsinhOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAsinhOp>(node, 1, 1);
     }else if (OpName == "Atan") {
-       ImportNodeOneOut<mlir::ONNXAtanOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAtanOp>(node, 1, 1);
     }else if (OpName == "Atanh") {
-       ImportNodeOneOut<mlir::ONNXAtanhOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXAtanhOp>(node, 1, 1);
     }else if (OpName == "AveragePool") {
-       ImportNodeOneOut<mlir::ONNXAveragePoolOp>(node, 1, 1, {
-         {"auto_pad", "NOTSET"}
-        ,{"ceil_mode", 0}
-        ,{"count_include_pad", 0}
-        ,{"kernel_shape", std::vector<int64_t> {}}
-      });
+       ImportNodeOneOut<mlir::ONNXAveragePoolOp>(node, 1, 1);
     }else if (OpName == "BatchNormalization") {
-       ImportNodeMultipleOuts<mlir::ONNXBatchNormalizationOp>(node, 5, 5, {
-         {"epsilon", (float)1e-05}
-        ,{"momentum", (float)0.9}
-      });
+       ImportNodeMultipleOuts<mlir::ONNXBatchNormalizationOp>(node, 5, 5);
     }else if (OpName == "BitShift") {
-       ImportNodeOneOut<mlir::ONNXBitShiftOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXBitShiftOp>(node, 2, 1);
     }else if (OpName == "Cast") {
-       ImportNodeOneOut<mlir::ONNXCastOp>(node, 1, 1, {
-         {"to", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXCastOp>(node, 1, 1);
     }else if (OpName == "Ceil") {
-       ImportNodeOneOut<mlir::ONNXCeilOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXCeilOp>(node, 1, 1);
     }else if (OpName == "Clip") {
-       ImportNodeOneOut<mlir::ONNXClipOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXClipOp>(node, 3, 1);
     }else if (OpName == "Compress") {
-       ImportNodeOneOut<mlir::ONNXCompressOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXCompressOp>(node, 2, 1);
     }else if (OpName == "Concat") {
-       ImportNodeOneOut<mlir::ONNXConcatOp>(node, 1, 1, {
-         {"axis", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXConcatOp>(node, 1, 1);
     }else if (OpName == "ConcatFromSequence") {
-       ImportNodeOneOut<mlir::ONNXConcatFromSequenceOp>(node, 1, 1, {
-         {"new_axis", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXConcatFromSequenceOp>(node, 1, 1);
     }else if (OpName == "Constant") {
-       ImportNodeOneOut<mlir::ONNXConstantOp>(node, 0, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXConstantOp>(node, 0, 1);
     }else if (OpName == "ConstantOfShape") {
-       ImportNodeOneOut<mlir::ONNXConstantOfShapeOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXConstantOfShapeOp>(node, 1, 1);
     }else if (OpName == "Conv") {
-       ImportNodeConv(node, 3, 1, {
-         {"auto_pad", "NOTSET"}
-        ,{"group", 1}
-      });
+       ImportNodeConv(node, 3, 1);
     }else if (OpName == "ConvInteger") {
-       ImportNodeOneOut<mlir::ONNXConvIntegerOp>(node, 4, 1, {
-         {"auto_pad", "NOTSET"}
-        ,{"group", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXConvIntegerOp>(node, 4, 1);
     }else if (OpName == "ConvTranspose") {
-       ImportNodeOneOut<mlir::ONNXConvTransposeOp>(node, 3, 1, {
-         {"auto_pad", "NOTSET"}
-        ,{"group", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXConvTransposeOp>(node, 3, 1);
     }else if (OpName == "Cos") {
-       ImportNodeOneOut<mlir::ONNXCosOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXCosOp>(node, 1, 1);
     }else if (OpName == "Cosh") {
-       ImportNodeOneOut<mlir::ONNXCoshOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXCoshOp>(node, 1, 1);
     }else if (OpName == "CumSum") {
-       ImportNodeOneOut<mlir::ONNXCumSumOp>(node, 2, 1, {
-         {"exclusive", 0}
-        ,{"reverse", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXCumSumOp>(node, 2, 1);
     }else if (OpName == "DepthToSpace") {
-       ImportNodeOneOut<mlir::ONNXDepthToSpaceOp>(node, 1, 1, {
-         {"mode", "DCR"}
-      });
+       ImportNodeOneOut<mlir::ONNXDepthToSpaceOp>(node, 1, 1);
     }else if (OpName == "DequantizeLinear") {
-       ImportNodeOneOut<mlir::ONNXDequantizeLinearOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXDequantizeLinearOp>(node, 3, 1);
     }else if (OpName == "Det") {
-       ImportNodeOneOut<mlir::ONNXDetOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXDetOp>(node, 1, 1);
     }else if (OpName == "Div") {
-       ImportNodeOneOut<mlir::ONNXDivOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXDivOp>(node, 2, 1);
     }else if (OpName == "Dropout") {
-       ImportNodeMultipleOuts<mlir::ONNXDropoutOp>(node, 1, 2, {
-         {"ratio", (float)0.5}
-      });
+       ImportNodeMultipleOuts<mlir::ONNXDropoutOp>(node, 1, 2);
     }else if (OpName == "DynamicQuantizeLinear") {
-       ImportNodeMultipleOuts<mlir::ONNXDynamicQuantizeLinearOp>(node, 1, 3, {
-      });
+       ImportNodeMultipleOuts<mlir::ONNXDynamicQuantizeLinearOp>(node, 1, 3);
     }else if (OpName == "Elu") {
-       ImportNodeOneOut<mlir::ONNXEluOp>(node, 1, 1, {
-         {"alpha", (float)1.0}
-      });
+       ImportNodeOneOut<mlir::ONNXEluOp>(node, 1, 1);
     }else if (OpName == "Equal") {
-       ImportNodeOneOut<mlir::ONNXEqualOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXEqualOp>(node, 2, 1);
     }else if (OpName == "Erf") {
-       ImportNodeOneOut<mlir::ONNXErfOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXErfOp>(node, 1, 1);
     }else if (OpName == "Exp") {
-       ImportNodeOneOut<mlir::ONNXExpOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXExpOp>(node, 1, 1);
     }else if (OpName == "Expand") {
-       ImportNodeOneOut<mlir::ONNXExpandOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXExpandOp>(node, 2, 1);
     }else if (OpName == "EyeLike") {
-       ImportNodeOneOut<mlir::ONNXEyeLikeOp>(node, 1, 1, {
-         {"k", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXEyeLikeOp>(node, 1, 1);
     }else if (OpName == "Flatten") {
-       ImportNodeOneOut<mlir::ONNXFlattenOp>(node, 1, 1, {
-         {"axis", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXFlattenOp>(node, 1, 1);
     }else if (OpName == "Floor") {
-       ImportNodeOneOut<mlir::ONNXFloorOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXFloorOp>(node, 1, 1);
     }else if (OpName == "GRU") {
-       ImportNodeMultipleOuts<mlir::ONNXGRUOp>(node, 6, 2, {
-         {"direction", "forward"}
-        ,{"linear_before_reset", 0}
-      });
+       ImportNodeMultipleOuts<mlir::ONNXGRUOp>(node, 6, 2);
     }else if (OpName == "Gather") {
-       ImportNodeOneOut<mlir::ONNXGatherOp>(node, 2, 1, {
-         {"axis", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXGatherOp>(node, 2, 1);
     }else if (OpName == "GatherElements") {
-       ImportNodeOneOut<mlir::ONNXGatherElementsOp>(node, 2, 1, {
-         {"axis", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXGatherElementsOp>(node, 2, 1);
     }else if (OpName == "GatherND") {
-       ImportNodeOneOut<mlir::ONNXGatherNDOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXGatherNDOp>(node, 2, 1);
     }else if (OpName == "Gemm") {
-       ImportNodeOneOut<mlir::ONNXGemmOp>(node, 3, 1, {
-         {"alpha", (float)1.0}
-        ,{"beta", (float)1.0}
-        ,{"transA", 0}
-        ,{"transB", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXGemmOp>(node, 3, 1);
     }else if (OpName == "GlobalAveragePool") {
-       ImportNodeOneOut<mlir::ONNXGlobalAveragePoolOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXGlobalAveragePoolOp>(node, 1, 1);
     }else if (OpName == "GlobalLpPool") {
-       ImportNodeOneOut<mlir::ONNXGlobalLpPoolOp>(node, 1, 1, {
-         {"p", 2}
-      });
+       ImportNodeOneOut<mlir::ONNXGlobalLpPoolOp>(node, 1, 1);
     }else if (OpName == "GlobalMaxPool") {
-       ImportNodeOneOut<mlir::ONNXGlobalMaxPoolOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXGlobalMaxPoolOp>(node, 1, 1);
     }else if (OpName == "Greater") {
-       ImportNodeOneOut<mlir::ONNXGreaterOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXGreaterOp>(node, 2, 1);
     }else if (OpName == "HardSigmoid") {
-       ImportNodeOneOut<mlir::ONNXHardSigmoidOp>(node, 1, 1, {
-         {"alpha", (float)0.2}
-        ,{"beta", (float)0.5}
-      });
+       ImportNodeOneOut<mlir::ONNXHardSigmoidOp>(node, 1, 1);
     }else if (OpName == "Hardmax") {
-       ImportNodeOneOut<mlir::ONNXHardmaxOp>(node, 1, 1, {
-         {"axis", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXHardmaxOp>(node, 1, 1);
     }else if (OpName == "Identity") {
-       ImportNodeOneOut<mlir::ONNXIdentityOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXIdentityOp>(node, 1, 1);
     }else if (OpName == "If") {
-       ImportNodeOneOut<mlir::ONNXIfOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXIfOp>(node, 1, 1);
     }else if (OpName == "InstanceNormalization") {
-       ImportNodeOneOut<mlir::ONNXInstanceNormalizationOp>(node, 3, 1, {
-         {"epsilon", (float)1e-05}
-      });
+       ImportNodeOneOut<mlir::ONNXInstanceNormalizationOp>(node, 3, 1);
     }else if (OpName == "IsInf") {
-       ImportNodeOneOut<mlir::ONNXIsInfOp>(node, 1, 1, {
-         {"detect_negative", 1}
-        ,{"detect_positive", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXIsInfOp>(node, 1, 1);
     }else if (OpName == "IsNaN") {
-       ImportNodeOneOut<mlir::ONNXIsNaNOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXIsNaNOp>(node, 1, 1);
     }else if (OpName == "LRN") {
-       ImportNodeOneOut<mlir::ONNXLRNOp>(node, 1, 1, {
-         {"alpha", (float)0.0001}
-        ,{"beta", (float)0.75}
-        ,{"bias", (float)1.0}
-      });
+       ImportNodeOneOut<mlir::ONNXLRNOp>(node, 1, 1);
     }else if (OpName == "LSTM") {
-       ImportNodeMultipleOuts<mlir::ONNXLSTMOp>(node, 8, 3, {
-         {"direction", "forward"}
-        ,{"input_forget", 0}
-      });
+       ImportNodeMultipleOuts<mlir::ONNXLSTMOp>(node, 8, 3);
     }else if (OpName == "LeakyRelu") {
-       ImportNodeOneOut<mlir::ONNXLeakyReluOp>(node, 1, 1, {
-         {"alpha", (float)0.01}
-      });
+       ImportNodeOneOut<mlir::ONNXLeakyReluOp>(node, 1, 1);
     }else if (OpName == "Less") {
-       ImportNodeOneOut<mlir::ONNXLessOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXLessOp>(node, 2, 1);
     }else if (OpName == "Log") {
-       ImportNodeOneOut<mlir::ONNXLogOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXLogOp>(node, 1, 1);
     }else if (OpName == "LogSoftmax") {
-       ImportNodeOneOut<mlir::ONNXLogSoftmaxOp>(node, 1, 1, {
-         {"axis", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXLogSoftmaxOp>(node, 1, 1);
     }else if (OpName == "Loop") {
-       ImportNodeOneOut<mlir::ONNXLoopOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXLoopOp>(node, 3, 1);
     }else if (OpName == "LpNormalization") {
-       ImportNodeOneOut<mlir::ONNXLpNormalizationOp>(node, 1, 1, {
-         {"axis", -1}
-        ,{"p", 2}
-      });
+       ImportNodeOneOut<mlir::ONNXLpNormalizationOp>(node, 1, 1);
     }else if (OpName == "LpPool") {
-       ImportNodeOneOut<mlir::ONNXLpPoolOp>(node, 1, 1, {
-         {"auto_pad", "NOTSET"}
-        ,{"p", 2}
-      });
+       ImportNodeOneOut<mlir::ONNXLpPoolOp>(node, 1, 1);
     }else if (OpName == "MatMul") {
-       ImportNodeOneOut<mlir::ONNXMatMulOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXMatMulOp>(node, 2, 1);
     }else if (OpName == "MatMulInteger") {
-       ImportNodeOneOut<mlir::ONNXMatMulIntegerOp>(node, 4, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXMatMulIntegerOp>(node, 4, 1);
     }else if (OpName == "Max") {
-       ImportNodeOneOut<mlir::ONNXMaxOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXMaxOp>(node, 1, 1);
     }else if (OpName == "MaxPool") {
-       ImportNodeMaxPool(node, 1, 2, {
-         {"auto_pad", "NOTSET"}
-        ,{"ceil_mode", 0}
-        ,{"kernel_shape", std::vector<int64_t> {}}
-        ,{"storage_order", 0}
-      });
+       ImportNodeMaxPool(node, 1, 2);
     }else if (OpName == "MaxRoiPool") {
-       ImportNodeOneOut<mlir::ONNXMaxRoiPoolOp>(node, 2, 1, {
-         {"spatial_scale", (float)1.0}
-      });
+       ImportNodeOneOut<mlir::ONNXMaxRoiPoolOp>(node, 2, 1);
     }else if (OpName == "MaxUnpool") {
-       ImportNodeOneOut<mlir::ONNXMaxUnpoolOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXMaxUnpoolOp>(node, 3, 1);
     }else if (OpName == "Mean") {
-       ImportNodeOneOut<mlir::ONNXMeanOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXMeanOp>(node, 1, 1);
     }else if (OpName == "MeanVarianceNormalization") {
-       ImportNodeOneOut<mlir::ONNXMeanVarianceNormalizationOp>(node, 1, 1, {
-         {"axes", std::vector<int64_t>{0, 2, 3}}
-      });
+       ImportNodeOneOut<mlir::ONNXMeanVarianceNormalizationOp>(node, 1, 1);
     }else if (OpName == "Min") {
-       ImportNodeOneOut<mlir::ONNXMinOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXMinOp>(node, 1, 1);
     }else if (OpName == "Mod") {
-       ImportNodeOneOut<mlir::ONNXModOp>(node, 2, 1, {
-         {"fmod", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXModOp>(node, 2, 1);
     }else if (OpName == "Mul") {
-       ImportNodeOneOut<mlir::ONNXMulOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXMulOp>(node, 2, 1);
     }else if (OpName == "Multinomial") {
-       ImportNodeOneOut<mlir::ONNXMultinomialOp>(node, 1, 1, {
-         {"dtype", 6}
-        ,{"sample_size", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXMultinomialOp>(node, 1, 1);
     }else if (OpName == "Neg") {
-       ImportNodeOneOut<mlir::ONNXNegOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXNegOp>(node, 1, 1);
     }else if (OpName == "NonMaxSuppression") {
-       ImportNodeOneOut<mlir::ONNXNonMaxSuppressionOp>(node, 5, 1, {
-         {"center_point_box", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXNonMaxSuppressionOp>(node, 5, 1);
     }else if (OpName == "NonZero") {
-       ImportNodeOneOut<mlir::ONNXNonZeroOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXNonZeroOp>(node, 1, 1);
     }else if (OpName == "Not") {
-       ImportNodeOneOut<mlir::ONNXNotOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXNotOp>(node, 1, 1);
     }else if (OpName == "OneHot") {
-       ImportNodeOneOut<mlir::ONNXOneHotOp>(node, 3, 1, {
-         {"axis", -1}
-      });
+       ImportNodeOneOut<mlir::ONNXOneHotOp>(node, 3, 1);
     }else if (OpName == "Or") {
-       ImportNodeOneOut<mlir::ONNXOrOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXOrOp>(node, 2, 1);
     }else if (OpName == "PRelu") {
-       ImportNodeOneOut<mlir::ONNXPReluOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXPReluOp>(node, 2, 1);
     }else if (OpName == "Pad") {
-       ImportNodeOneOut<mlir::ONNXPadOp>(node, 3, 1, {
-         {"mode", "constant"}
-      });
+       ImportNodeOneOut<mlir::ONNXPadOp>(node, 3, 1);
     }else if (OpName == "Pow") {
-       ImportNodeOneOut<mlir::ONNXPowOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXPowOp>(node, 2, 1);
     }else if (OpName == "QLinearConv") {
-       ImportNodeOneOut<mlir::ONNXQLinearConvOp>(node, 9, 1, {
-         {"auto_pad", "NOTSET"}
-        ,{"group", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXQLinearConvOp>(node, 9, 1);
     }else if (OpName == "QLinearMatMul") {
-       ImportNodeOneOut<mlir::ONNXQLinearMatMulOp>(node, 8, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXQLinearMatMulOp>(node, 8, 1);
     }else if (OpName == "QuantizeLinear") {
-       ImportNodeOneOut<mlir::ONNXQuantizeLinearOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXQuantizeLinearOp>(node, 3, 1);
     }else if (OpName == "RNN") {
-       ImportNodeMultipleOuts<mlir::ONNXRNNOp>(node, 6, 2, {
-         {"activation_alpha", std::vector<float> {}}
-        ,{"activation_beta", std::vector<float> {}}
-        ,{"activations", std::vector<std::string>{"Tanh", "Tanh"}}
-        ,{"direction", "forward"}
-      });
+       ImportNodeMultipleOuts<mlir::ONNXRNNOp>(node, 6, 2);
     }else if (OpName == "RandomNormal") {
-       ImportNodeOneOut<mlir::ONNXRandomNormalOp>(node, 0, 1, {
-         {"dtype", 1}
-        ,{"mean", (float)0.0}
-        ,{"scale", (float)1.0}
-      });
+       ImportNodeOneOut<mlir::ONNXRandomNormalOp>(node, 0, 1);
     }else if (OpName == "RandomNormalLike") {
-       ImportNodeOneOut<mlir::ONNXRandomNormalLikeOp>(node, 1, 1, {
-         {"mean", (float)0.0}
-        ,{"scale", (float)1.0}
-      });
+       ImportNodeOneOut<mlir::ONNXRandomNormalLikeOp>(node, 1, 1);
     }else if (OpName == "RandomUniform") {
-       ImportNodeOneOut<mlir::ONNXRandomUniformOp>(node, 0, 1, {
-         {"dtype", 1}
-        ,{"high", (float)1.0}
-        ,{"low", (float)0.0}
-      });
+       ImportNodeOneOut<mlir::ONNXRandomUniformOp>(node, 0, 1);
     }else if (OpName == "RandomUniformLike") {
-       ImportNodeOneOut<mlir::ONNXRandomUniformLikeOp>(node, 1, 1, {
-         {"high", (float)1.0}
-        ,{"low", (float)0.0}
-      });
+       ImportNodeOneOut<mlir::ONNXRandomUniformLikeOp>(node, 1, 1);
     }else if (OpName == "Range") {
-       ImportNodeOneOut<mlir::ONNXRangeOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXRangeOp>(node, 3, 1);
     }else if (OpName == "Reciprocal") {
-       ImportNodeOneOut<mlir::ONNXReciprocalOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXReciprocalOp>(node, 1, 1);
     }else if (OpName == "ReduceL1") {
-       ImportNodeOneOut<mlir::ONNXReduceL1Op>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceL1Op>(node, 1, 1);
     }else if (OpName == "ReduceL2") {
-       ImportNodeOneOut<mlir::ONNXReduceL2Op>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceL2Op>(node, 1, 1);
     }else if (OpName == "ReduceLogSum") {
-       ImportNodeOneOut<mlir::ONNXReduceLogSumOp>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceLogSumOp>(node, 1, 1);
     }else if (OpName == "ReduceLogSumExp") {
-       ImportNodeOneOut<mlir::ONNXReduceLogSumExpOp>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceLogSumExpOp>(node, 1, 1);
     }else if (OpName == "ReduceMax") {
-       ImportNodeOneOut<mlir::ONNXReduceMaxOp>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceMaxOp>(node, 1, 1);
     }else if (OpName == "ReduceMean") {
-       ImportNodeOneOut<mlir::ONNXReduceMeanOp>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceMeanOp>(node, 1, 1);
     }else if (OpName == "ReduceMin") {
-       ImportNodeOneOut<mlir::ONNXReduceMinOp>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceMinOp>(node, 1, 1);
     }else if (OpName == "ReduceProd") {
-       ImportNodeOneOut<mlir::ONNXReduceProdOp>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceProdOp>(node, 1, 1);
     }else if (OpName == "ReduceSum") {
-       ImportNodeOneOut<mlir::ONNXReduceSumOp>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceSumOp>(node, 1, 1);
     }else if (OpName == "ReduceSumSquare") {
-       ImportNodeOneOut<mlir::ONNXReduceSumSquareOp>(node, 1, 1, {
-         {"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXReduceSumSquareOp>(node, 1, 1);
     }else if (OpName == "Relu") {
-       ImportNodeOneOut<mlir::ONNXReluOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXReluOp>(node, 1, 1);
     }else if (OpName == "Reshape") {
-       ImportNodeOneOut<mlir::ONNXReshapeOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXReshapeOp>(node, 2, 1);
     }else if (OpName == "Resize") {
-       ImportNodeOneOut<mlir::ONNXResizeOp>(node, 4, 1, {
-         {"coordinate_transformation_mode", "half_pixel"}
-        ,{"cubic_coeff_a", (float)-0.75}
-        ,{"exclude_outside", 0}
-        ,{"extrapolation_value", (float)0.0}
-        ,{"mode", "nearest"}
-        ,{"nearest_mode", "round_prefer_floor"}
-      });
+       ImportNodeOneOut<mlir::ONNXResizeOp>(node, 4, 1);
     }else if (OpName == "ReverseSequence") {
-       ImportNodeOneOut<mlir::ONNXReverseSequenceOp>(node, 2, 1, {
-         {"batch_axis", 1}
-        ,{"time_axis", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXReverseSequenceOp>(node, 2, 1);
     }else if (OpName == "RoiAlign") {
-       ImportNodeOneOut<mlir::ONNXRoiAlignOp>(node, 3, 1, {
-         {"mode", "avg"}
-        ,{"output_height", 1}
-        ,{"output_width", 1}
-        ,{"sampling_ratio", 0}
-        ,{"spatial_scale", (float)1.0}
-      });
+       ImportNodeOneOut<mlir::ONNXRoiAlignOp>(node, 3, 1);
     }else if (OpName == "Round") {
-       ImportNodeOneOut<mlir::ONNXRoundOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXRoundOp>(node, 1, 1);
     }else if (OpName == "Scan") {
-       ImportNodeOneOut<mlir::ONNXScanOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXScanOp>(node, 1, 1);
     }else if (OpName == "Scatter") {
-       ImportNodeOneOut<mlir::ONNXScatterOp>(node, 3, 1, {
-         {"axis", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXScatterOp>(node, 3, 1);
     }else if (OpName == "ScatterElements") {
-       ImportNodeOneOut<mlir::ONNXScatterElementsOp>(node, 3, 1, {
-         {"axis", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXScatterElementsOp>(node, 3, 1);
     }else if (OpName == "ScatterND") {
-       ImportNodeOneOut<mlir::ONNXScatterNDOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXScatterNDOp>(node, 3, 1);
     }else if (OpName == "Selu") {
-       ImportNodeOneOut<mlir::ONNXSeluOp>(node, 1, 1, {
-         {"alpha", (float)1.67326}
-        ,{"gamma", (float)1.0507}
-      });
+       ImportNodeOneOut<mlir::ONNXSeluOp>(node, 1, 1);
     }else if (OpName == "SequenceAt") {
-       ImportNodeOneOut<mlir::ONNXSequenceAtOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSequenceAtOp>(node, 2, 1);
     }else if (OpName == "SequenceConstruct") {
-       ImportNodeOneOut<mlir::ONNXSequenceConstructOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSequenceConstructOp>(node, 1, 1);
     }else if (OpName == "SequenceEmpty") {
-       ImportNodeOneOut<mlir::ONNXSequenceEmptyOp>(node, 0, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSequenceEmptyOp>(node, 0, 1);
     }else if (OpName == "SequenceErase") {
-       ImportNodeOneOut<mlir::ONNXSequenceEraseOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSequenceEraseOp>(node, 2, 1);
     }else if (OpName == "SequenceInsert") {
-       ImportNodeOneOut<mlir::ONNXSequenceInsertOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSequenceInsertOp>(node, 3, 1);
     }else if (OpName == "SequenceLength") {
-       ImportNodeOneOut<mlir::ONNXSequenceLengthOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSequenceLengthOp>(node, 1, 1);
     }else if (OpName == "Shape") {
-       ImportNodeOneOut<mlir::ONNXShapeOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXShapeOp>(node, 1, 1);
     }else if (OpName == "Shrink") {
-       ImportNodeOneOut<mlir::ONNXShrinkOp>(node, 1, 1, {
-         {"bias", (float)0.0}
-        ,{"lambd", (float)0.5}
-      });
+       ImportNodeOneOut<mlir::ONNXShrinkOp>(node, 1, 1);
     }else if (OpName == "Sigmoid") {
-       ImportNodeOneOut<mlir::ONNXSigmoidOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSigmoidOp>(node, 1, 1);
     }else if (OpName == "Sign") {
-       ImportNodeOneOut<mlir::ONNXSignOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSignOp>(node, 1, 1);
     }else if (OpName == "Sin") {
-       ImportNodeOneOut<mlir::ONNXSinOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSinOp>(node, 1, 1);
     }else if (OpName == "Sinh") {
-       ImportNodeOneOut<mlir::ONNXSinhOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSinhOp>(node, 1, 1);
     }else if (OpName == "Size") {
-       ImportNodeOneOut<mlir::ONNXSizeOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSizeOp>(node, 1, 1);
     }else if (OpName == "Slice") {
-       ImportNodeOneOut<mlir::ONNXSliceOp>(node, 5, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSliceOp>(node, 5, 1);
     }else if (OpName == "Softmax") {
-       ImportNodeOneOut<mlir::ONNXSoftmaxOp>(node, 1, 1, {
-         {"axis", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXSoftmaxOp>(node, 1, 1);
     }else if (OpName == "Softplus") {
-       ImportNodeOneOut<mlir::ONNXSoftplusOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSoftplusOp>(node, 1, 1);
     }else if (OpName == "Softsign") {
-       ImportNodeOneOut<mlir::ONNXSoftsignOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSoftsignOp>(node, 1, 1);
     }else if (OpName == "SpaceToDepth") {
-       ImportNodeOneOut<mlir::ONNXSpaceToDepthOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSpaceToDepthOp>(node, 1, 1);
     }else if (OpName == "Split") {
-       ImportNodeOneOut<mlir::ONNXSplitOp>(node, 1, 1, {
-         {"axis", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXSplitOp>(node, 1, 1);
     }else if (OpName == "SplitToSequence") {
-       ImportNodeOneOut<mlir::ONNXSplitToSequenceOp>(node, 2, 1, {
-         {"axis", 0}
-        ,{"keepdims", 1}
-      });
+       ImportNodeOneOut<mlir::ONNXSplitToSequenceOp>(node, 2, 1);
     }else if (OpName == "Sqrt") {
-       ImportNodeOneOut<mlir::ONNXSqrtOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSqrtOp>(node, 1, 1);
     }else if (OpName == "Squeeze") {
-       ImportNodeOneOut<mlir::ONNXSqueezeOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSqueezeOp>(node, 1, 1);
     }else if (OpName == "StringNormalizer") {
-       ImportNodeOneOut<mlir::ONNXStringNormalizerOp>(node, 1, 1, {
-         {"case_change_action", "NONE"}
-        ,{"is_case_sensitive", 0}
-      });
+       ImportNodeOneOut<mlir::ONNXStringNormalizerOp>(node, 1, 1);
     }else if (OpName == "Sub") {
-       ImportNodeOneOut<mlir::ONNXSubOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSubOp>(node, 2, 1);
     }else if (OpName == "Sum") {
-       ImportNodeOneOut<mlir::ONNXSumOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXSumOp>(node, 1, 1);
     }else if (OpName == "Tan") {
-       ImportNodeOneOut<mlir::ONNXTanOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXTanOp>(node, 1, 1);
     }else if (OpName == "Tanh") {
-       ImportNodeOneOut<mlir::ONNXTanhOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXTanhOp>(node, 1, 1);
     }else if (OpName == "TfIdfVectorizer") {
-       ImportNodeOneOut<mlir::ONNXTfIdfVectorizerOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXTfIdfVectorizerOp>(node, 1, 1);
     }else if (OpName == "ThresholdedRelu") {
-       ImportNodeOneOut<mlir::ONNXThresholdedReluOp>(node, 1, 1, {
-         {"alpha", (float)1.0}
-      });
+       ImportNodeOneOut<mlir::ONNXThresholdedReluOp>(node, 1, 1);
     }else if (OpName == "Tile") {
-       ImportNodeOneOut<mlir::ONNXTileOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXTileOp>(node, 2, 1);
     }else if (OpName == "TopK") {
-       ImportNodeMultipleOuts<mlir::ONNXTopKOp>(node, 2, 2, {
-         {"axis", -1}
-        ,{"largest", 1}
-        ,{"sorted", 1}
-      });
+       ImportNodeMultipleOuts<mlir::ONNXTopKOp>(node, 2, 2);
     }else if (OpName == "Transpose") {
-       ImportNodeOneOut<mlir::ONNXTransposeOp>(node, 1, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXTransposeOp>(node, 1, 1);
     }else if (OpName == "Unique") {
-       ImportNodeMultipleOuts<mlir::ONNXUniqueOp>(node, 1, 4, {
-         {"sorted", 1}
-      });
+       ImportNodeMultipleOuts<mlir::ONNXUniqueOp>(node, 1, 4);
     }else if (OpName == "Unsqueeze") {
-       ImportNodeOneOut<mlir::ONNXUnsqueezeOp>(node, 1, 1, {
-         {"axes", std::vector<int64_t> {}}
-      });
+       ImportNodeOneOut<mlir::ONNXUnsqueezeOp>(node, 1, 1);
     }else if (OpName == "Upsample") {
-       ImportNodeOneOut<mlir::ONNXUpsampleOp>(node, 2, 1, {
-         {"mode", "nearest"}
-      });
+       ImportNodeOneOut<mlir::ONNXUpsampleOp>(node, 2, 1);
     }else if (OpName == "Where") {
-       ImportNodeOneOut<mlir::ONNXWhereOp>(node, 3, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXWhereOp>(node, 3, 1);
     }else if (OpName == "Xor") {
-       ImportNodeOneOut<mlir::ONNXXorOp>(node, 2, 1, {
-      });
+       ImportNodeOneOut<mlir::ONNXXorOp>(node, 2, 1);
     }

--- a/src/dialect/onnx/gen_doc.py
+++ b/src/dialect/onnx/gen_doc.py
@@ -274,7 +274,7 @@ def gen_schema(schema) :
                     '    static StringRef getPermAttrName() { return "perm"; }\n'+
                     '    }];\n')
       ])
-    skip_attr_gen = ['Gemm']
+    skip_attr_gen = []
     line_indent = '  '
 
     #s = 'def ONNX'+schema.name+str(schema.since_version)+'Op:ONNX_Op<"'+schema.name+'", \n'
@@ -650,6 +650,6 @@ if __name__ == '__main__':
     class Args(object):
         output = os.path.join(docs_dir, 'Operators' + ext)
         changelog = os.path.join(docs_dir, 'Changelog' + ext)
-        tdfile = os.path.join(docs_dir, 'onnxop.inc')
+        tdfile = os.path.join(base_dir, 'onnxop.inc')
     print(Args)
     main(Args)

--- a/src/dialect/onnx/gen_doc.py
+++ b/src/dialect/onnx/gen_doc.py
@@ -356,6 +356,7 @@ def gen_schema(schema) :
                 s+= 'AnyTypeOf<[AnyMemRef, AnyTensor]>'
             else:
                 s+= 'TensorOf<['+etypes+']>'
+            s += ':$o_'+output.name
     s+= ');\n'
 
     #s+= 'let hasCanonicalizer = 1;'

--- a/src/dialect/onnx/gen_doc.py
+++ b/src/dialect/onnx/gen_doc.py
@@ -271,7 +271,7 @@ def gen_schema(schema) :
                         'Softplus', 'Softsign']
     CanonicalList=['Add', 'Identity']
     manual_code = dict([
-      ('Transpose', '  let extraClassDeclaration = [{ \n'+
+      ('DummyExample', '  let extraClassDeclaration = [{ \n'+
                     '    static StringRef getPermAttrName() { return "perm"; }\n'+
                     '    }];\n')
       ])

--- a/src/dialect/onnx/gen_doc.py
+++ b/src/dialect/onnx/gen_doc.py
@@ -413,7 +413,7 @@ def gen_attr_ins(schema, isfirst) :
     
     def get_attr_type_basic(attr_type) :
         if attr_type == 'int' :
-            mytype = 'I32Attr'
+            mytype = 'I64Attr'
         elif attr_type == 'float' :
             mytype = 'F32Attr'
         elif attr_type == 'ints' :

--- a/src/dialect/onnx/gen_doc.py
+++ b/src/dialect/onnx/gen_doc.py
@@ -269,6 +269,12 @@ def gen_schema(schema) :
                         'Elu', 'Selu', 'HardSigmoid', 'Reshape', 'Reciprocal',
                         'Identity', 'Cos', 'Log', 'Transpose', 'Softmax']
     CanonicalList=['Add', 'Identity']
+    manual_code = dict([
+      ('Transpose', '  let extraClassDeclaration = [{ \n'+
+                    '    static StringRef getPermAttrName() { return "perm"; }\n'+
+                    '    }];\n')
+      ])
+    skip_attr_gen = ['Gemm']
     line_indent = '  '
 
     #s = 'def ONNX'+schema.name+str(schema.since_version)+'Op:ONNX_Op<"'+schema.name+'", \n'
@@ -302,21 +308,23 @@ def gen_schema(schema) :
 
     #input
     s+= '\n'+line_indent+'let arguments = (ins '
+    isfirst = True
     if schema.inputs:
+        isfirst = False
         for input in schema.inputs:
             if input != schema.inputs[0] :
-                s+= ', '
+                s+= ',\n           '
             etypes=collect_types(schema, input)
 
             if OpSchema.FormalParameterOption.Optional == input.option:
                 #TODO: handle optional
-                print("optional ", input.name)
+                print("warning: optional input for"+schema.name+' '+input.name)
             elif OpSchema.FormalParameterOption.Variadic == input.option:
                 if input.isHomogeneous:
                     s+= 'Variadic<'
                 else:
                     #TODO handle  (variadic, heterogeneous)"
-                    print('variadic, heterogeneous', input.name)
+                    print("warning: (variadic, heterogeneous) for"+schema.name+' '+input.name)
             if etypes == '':
                 s+= 'AnyTypeOf<[AnyMemRef, AnyTensor]>'
             else:
@@ -332,6 +340,8 @@ def gen_schema(schema) :
                     #TODO handle  (variadic, heterogeneous)"
                     t=''
             s+=':$'+input.name
+    if not schema.name in skip_attr_gen :
+        s += gen_attr_ins(schema, isfirst)
     s+= ');'
 
     #output
@@ -346,11 +356,14 @@ def gen_schema(schema) :
                 s+= 'AnyTypeOf<[AnyMemRef, AnyTensor]>'
             else:
                 s+= 'TensorOf<['+etypes+']>'
-    s+= ');'
+    s+= ');\n'
 
     #s+= 'let hasCanonicalizer = 1;'
+    #add special code
+    if schema.name in manual_code :
+        s += manual_code[schema.name]
 
-    s += '\n}\n\n'
+    s += '}\n\n'
 
     return s
 
@@ -368,44 +381,91 @@ def gen_code(schema,fefile) :
         ("MaxPool", "ImportNodeMaxPool"),
         #("Transpose", "ImportNodeTranspose")
         ])
-    list_str = 'std::vector'
-    empty_ints = list_str+'<int> {}' 
-    empty_floats = list_str+'<float> {}' 
-    special_default = dict([
-        ("AveragePool "+"kernel_shape", empty_ints),
-        ("MaxPool "+"kernel_shape", empty_ints),
-        ("Cast "+"to", '0'),
-        ("Concat "+"axis", '0'),
-        ("Unsqueeze "+"axes", empty_ints),
-        ("RNN "+"activation_alpha", empty_floats),
-        ("RNN "+"activation_beta", empty_floats)
-        ])
+
     line_indent = '  '
     fefile.write('    '+'}else if (OpName == "'+schema.name+'") {\n')
     op_type_str='mlir::ONNX'+schema.name+'Op'
     if schema.name in special_handler :
         fefile.write('       '+special_handler[schema.name]+'(node, '
           +str(len(schema.inputs))
-          +', ' +str(len(schema.outputs))+', {\n')
+          +', ' +str(len(schema.outputs)))
     elif len(schema.outputs) > 1 :
         fefile.write('       '+'ImportNodeMultipleOuts<'+op_type_str+'>(node, '
           +str(len(schema.inputs))
-          +', ' +str(len(schema.outputs))+', {\n')
+          +', ' +str(len(schema.outputs)))
     else :
         fefile.write('       '+'ImportNodeOneOut<'+op_type_str+'>(node, '
           +str(len(schema.inputs))
-          +', ' +str(len(schema.outputs))+', {\n')
+          +', ' +str(len(schema.outputs)))
+    fefile.write(');\n')
+
+def gen_attr_ins(schema, isfirst) :
+    special_defaults = dict([
+        ("AveragePool "+"kernel_shape", ('ints', '{}')),
+        ("MaxPool "+"kernel_shape", ('ints', '{}')),
+        ("Cast "+"to", ('int', '0')),
+        ("Concat "+"axis", ('int', '0')),
+        ("Conv "+"group", ('int', '1')),
+        ("Unsqueeze "+"axes", ('ints', '{}')),
+        ("RNN "+"activation_alpha", ('floats', '{}')),
+        ("RNN "+"activation_beta", ('floats', '{}')),
+        ])
     
+    def get_attr_type_basic(attr_type) :
+        if attr_type == 'int' :
+            mytype = 'I32Attr'
+        elif attr_type == 'float' :
+            mytype = 'F32Attr'
+        elif attr_type == 'ints' :
+            mytype = 'I64ArrayAttr'
+        elif attr_type == 'floats' :
+            mytype = 'F32ArrayAttr'
+        elif attr_type == "string" :
+            mytype = 'StrAttr'
+        elif attr_type == "strings" :
+            mytype = 'StrArrayAttr'
+        else :
+            mytype ='AnyAttr'
+        #TODO: tensor and sparse tensor
+        return mytype
 
+    def get_attr_type_optional(attr_type) :
+        mytype = 'OptionalAttr<'
+        mytype += get_attr_type_basic(attr_type)
+        mytype += '>'
+        return mytype
+
+    def get_attr_type_with_default(attr_type, attr_default) :
+        mytype = 'DefaultValuedAttr<'
+        mytype += get_attr_type_basic(attr_type)
+        mytype += ', "'+attr_default+'">'
+        return mytype
+
+    attr_line = ''
     if schema.attributes:
-        first_attr = True
         for _, attr in sorted(schema.attributes.items()):
-            #only generate default attr list
-            if schema.name+' '+attr.name in special_default:
-                attr_value = special_default[schema.name+' '+attr.name]
-            elif attr.default_value.name:
-                default_value = helper.get_attribute_value(attr.default_value)
+            #attr_line = line_indent+line_indent+line_indent+line_indent
+            if not isfirst:
+                attr_line += ',\n           '
+            else :
+                isfirst = False
+            
+            if schema.name+' '+attr.name in special_defaults:
+                (attr_type_str, attr_default_str) = special_defaults[schema.name+' '+attr.name]
+                attr_line += get_attr_type_with_default(attr_type_str, attr_default_str)
+                attr_line += ':$'+attr.name
+            elif attr.required:
+                s = Text(attr.type)
+                attr_type_str  = s[s.rfind('.') + 1:].lower()
+                attr_line += get_attr_type_basic(attr_type_str)
+                attr_line += ':$'+attr.name
 
+            # option holds either required or default value
+            elif attr.default_value.name:
+                s = Text(attr.type)
+                attr_type_str  = s[s.rfind('.') + 1:].lower()
+
+                default_value = helper.get_attribute_value(attr.default_value)
                 def format_value(value):  # type: (Any) -> Text
                     if isinstance(value, float):
                         formatted = str(np.round(value, 5))
@@ -418,66 +478,25 @@ def gen_code(schema,fefile) :
                     return str(value)
 
                 if isinstance(default_value, list):
-
-                    value = default_value[0]
                     default_value = [format_value(val) for val in default_value]
                     attr_option_str = '{}'.format(default_value)
                     attr_option_str = attr_option_str.replace('[', '{', 1)
                     attr_option_str = attr_option_str.replace(']', '}', 1)
-                    # TODO the list type is homogenous or htergeneous?
-                   
-                    if isinstance(value, float) : 
-                        attr_type_str = list_str+'<float>'
-                        attr_option_str = attr_option_str.replace("'", '')
-                    elif isinstance(value, int) :
-                        attr_type_str = list_str+'<int>'
-                        attr_option_str = attr_option_str.replace("'", '')
-                    elif isinstance(value, str) :
-                        attr_type_str = list_str+'<std::string>'
-                        attr_option_str = attr_option_str.replace("'", '"')
-                    elif isinstance(value, (bytes, bytearray)) :
-                        attr_type_str = list_str+'<std::string>'
-                        attr_option_str = attr_option_str.replace("'", '"')
+                    if attr_type_str == 'strings' :
+                        attr_option_str = attr_option_str.replace("'", '\\"')
                     else :
-                        attr_type_str = '"unknowns"'
+                        attr_option_str = attr_option_str.replace("'", '')
                 else:
-                    if isinstance(default_value, float) : 
-                        attr_type_str = '(float)'
-                        attr_option_str = default_value
-                    elif isinstance(default_value, int) :
-                        attr_option_str = default_value
-                        attr_type_str=''
-                    elif isinstance(default_value, str) :
-                        attr_type_str = '"str"'
-                    elif isinstance(default_value, (bytes, bytearray)) :
-                        attr_type_str = '"str"'
-                    else :
-                        attr_type_str = '"unknown"'
                     default_value = format_value(default_value)
-                    if attr_type_str == '"str"' :
-                        attr_option_str = '"'+default_value+'"'
-                        attr_type_str=''
-                    else :
-                        attr_option_str = default_value
-                attr_value = attr_type_str+attr_option_str
+                    attr_option_str = default_value
+                attr_line += get_attr_type_with_default(attr_type_str, attr_option_str)
+                attr_line += ':$'+attr.name
             else:
-                #no default value
-                continue
-
-            attr_line = line_indent+line_indent+line_indent+line_indent
-            if not first_attr:
-                attr_line += ',{'
-            else :
-                attr_line += ' {'
-            first_attr = False
-
-            attr_line += '"'+attr.name+'", '
-            attr_line += attr_value
-            attr_line += '}\n'
-            fefile.write(attr_line)
-    fefile.write(line_indent+line_indent+line_indent+'});\n')
-          
-
+                s = Text(attr.type)
+                attr_type_str  = s[s.rfind('.') + 1:].lower()
+                attr_line += get_attr_type_optional(attr_type_str)
+                attr_line += ':$'+attr.name
+    return attr_line
 
 def main(args):  # type: (Type[Args]) -> None
     with io.open(args.changelog, 'w', newline='') as fout:
@@ -495,7 +514,6 @@ def main(args):  # type: (Type[Args]) -> None
         fout.write('\n')
 
         for domain, versionmap in sorted(dv_index.items()):
-            print("domain", domain)
             if not should_render_domain(domain):
                 continue
 

--- a/src/dialect/onnx/onnx.td
+++ b/src/dialect/onnx/onnx.td
@@ -99,8 +99,14 @@ def ONNXGemmNoBiasOp: ONNX_Op<"GemmNoBias",
 
   }];
 
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$lhs_in, AnyTypeOf<[AnyMemRef, AnyTensor]>:$rhs_in);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           DefaultValuedAttr<F32Attr, "1.0">:$alpha,
+           DefaultValuedAttr<F32Attr, "1.0">:$beta,
+           DefaultValuedAttr<I64Attr, "0">:$transA,
+           DefaultValuedAttr<I64Attr, "0">:$transB);
+
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXConvNoBiasOp:ONNX_Op<"ConvNoBias",
@@ -110,10 +116,15 @@ def ONNXConvNoBiasOp:ONNX_Op<"ConvNoBias",
     "The convolution operator consumes an input tensor and a filter, and"
     "computes the output."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$W);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
-
-  let verifier = [{ return ::verify(*this); }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$W,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           OptionalAttr<I64ArrayAttr>:$dilations,
+           DefaultValuedAttr<I64Attr, "1">:$group,
+           OptionalAttr<I64ArrayAttr>:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           OptionalAttr<I64ArrayAttr>:$strides);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXMaxPoolSingleOutOp: ONNX_Op<"MaxPoolSingleOut",
@@ -123,8 +134,15 @@ def ONNXMaxPoolSingleOutOp: ONNX_Op<"MaxPoolSingleOut",
     "ONNX MaxPool operation with a single output."
     "See ONNXMaxPoolOp for a full description of the MaxPool semantics."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           DefaultValuedAttr<I64Attr, "0">:$ceil_mode,
+           OptionalAttr<I64ArrayAttr>:$dilations,
+           DefaultValuedAttr<I64ArrayAttr, "{}">:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           DefaultValuedAttr<I64Attr, "0">:$storage_order,
+           OptionalAttr<I64ArrayAttr>:$strides);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 #endif // ONNX_OPS

--- a/src/dialect/onnx/onnx_ops.cpp
+++ b/src/dialect/onnx/onnx_ops.cpp
@@ -419,8 +419,10 @@ void ONNXTransposeOp::inferShapes() {
   auto arrayTy = getOperand().getType().cast<RankedTensorType>();
   SmallVector<int64_t, 2> dims;
 
-  if (auto permutation = getAttrOfType<ArrayAttr>(
-          ONNXTransposeOp::getPermAttrName())) {
+  //if (auto permutation = getAttrOfType<ArrayAttr>(
+   //       ONNXTransposeOp::getPermAttrName())) {
+  auto permutation = ONNXTransposeOp::permAttr();
+  if (permutation) {
     // Perform transposition according to perm attribute.
     for (auto perm : permutation.getValue())
       dims.emplace_back(arrayTy.getShape()[perm.cast<IntegerAttr>().getInt()]);

--- a/src/dialect/onnx/onnx_ops.cpp
+++ b/src/dialect/onnx/onnx_ops.cpp
@@ -451,20 +451,6 @@ void ONNXTransposeOp::inferShapes() {
   getResult().setType(RankedTensorType::get(dims, arrayTy.getElementType()));
 }
 
-LogicalResult verify(ONNXTransposeOp op) {
-  auto module = op.getParentOfType<ModuleOp>();
-  if (!module)
-    op.emitError("Expected to belong to a module.");
-
-  if (auto permutation = op.getAttrOfType<ArrayAttr>(
-          ONNXTransposeOp::getPermAttrName())) {
-    for (auto perm : permutation.getValue())
-      if (perm.cast<IntegerAttr>().getInt() < 0)
-        op.emitError("Cannot tranpose, permuation contains negative index.");
-  }
-
-  return success();
-}
 
 //===----------------------------------------------------------------------===//
 
@@ -493,11 +479,9 @@ void ONNXConvNoBiasOp::inferShapes() {
     emitError("Weight size not compatible with data size.");
 
   // Required attribute auto_pad defaults to NOTSET.
-  auto autoPad = getAttrOfType<StringAttr>(
-      ONNXConvOp::getAutoPadAttrName()).getValue();
+  auto autoPad = auto_pad();
   // Group is a required attribute and should have default value of 1.
-  int64_t group = getAttrOfType<IntegerAttr>(
-      ONNXConvOp::getGroupAttrName()).getInt();
+  int64_t group = ONNXConvNoBiasOp::group().getSExtValue(); //.getLimitedValue();
   // Check that the X.shape[1] == (W.shape[1] * group) == C condition holds.
   if (dataShape[1] != (weightShape[1] * group))
     emitError("Channel dimension mismatch.");
@@ -529,8 +513,7 @@ void ONNXConvNoBiasOp::inferShapes() {
   // Use kernel_shape attribute if present otherwise use size from weight
   // argument.
   SmallVector<int64_t, 2> kernelDims;
-  if (auto kernelShape = getAttrOfType<ArrayAttr>(
-          ONNXConvOp::getKernelShapeAttrName())) {
+  if (auto kernelShape = kernel_shapeAttr()) {
     if (kernelShape.getValue().size() != nDims)
       emitError("kernel_shape length incompatible with spatial dimensions.");
     for (int i = 0; i < nDims; ++i)
@@ -552,8 +535,7 @@ void ONNXConvNoBiasOp::inferShapes() {
   //
   // From a dimensionality perspective the kernel size becomes the dilated
   // kernel size.
-  if (auto dilations = getAttrOfType<ArrayAttr>(
-          ONNXConvOp::getDilationsAttrName())) {
+  if (auto dilations = dilationsAttr()) {
     if (dilations.getValue().size() != nDims)
       emitError("dilations length incompatible with spatial dimensions.");
     for (int i = 0; i < nDims; ++i)
@@ -569,8 +551,7 @@ void ONNXConvNoBiasOp::inferShapes() {
   if (autoPad == "NOTSET") {
     // Use pads to to determine the padding. If attribute is not
     // present then pads is considered to be all zeros (no padding).
-    if (auto pads = getAttrOfType<ArrayAttr>(
-            ONNXConvOp::getPadsAttrName())) {
+    if (auto pads = padsAttr()) {
       // pads consists of two entries for each spatial axis.
       if (pads.getValue().size() != 2 * nDims)
         emitError("pads size is not twice the spatial size.");
@@ -601,13 +582,12 @@ void ONNXConvNoBiasOp::inferShapes() {
   }
 
   // Strides
-  if (auto strides = getAttrOfType<ArrayAttr>(
-      ONNXConvOp::getStridesAttrName())) {
+  if (auto strides = ONNXConvNoBiasOp::stridesAttr()) {
     if (strides.getValue().size() != nDims)
       emitError("strides length incompatible with spatial dimensions.");
     for (int i = 0; i < nDims; ++i) {
       int64_t stride =
-          (strides.getValue()[i]).cast<IntegerAttr>().getInt();
+          strides.getValue()[i].cast<IntegerAttr>().getInt();
       outSpatialDims[i] = floor(outSpatialDims[i] / stride);
     }
   }
@@ -617,28 +597,6 @@ void ONNXConvNoBiasOp::inferShapes() {
 
   dims.append(outSpatialDims.begin(), outSpatialDims.end());
   getResult().setType(RankedTensorType::get(dims, dataTy.getElementType()));
-}
-
-LogicalResult verify(ONNXConvNoBiasOp op) {
-  auto module = op.getParentOfType<ModuleOp>();
-  if (!module)
-    op.emitError("expected to belong to a module");
-
-  auto autoPadAttr = op.getAttrOfType<StringAttr>(
-      ONNXConvOp::getAutoPadAttrName());
-  if (!autoPadAttr)
-    op.emitError("auto_pad attribute not specified.");
-  if (autoPadAttr.getValue() != "NOTSET")
-    if (auto pads = op.getAttrOfType<ArrayAttr>(
-            ONNXConvOp::getPadsAttrName()))
-      op.emitError("auto_pad and pads are both set.");
-
-  auto groupAttr =
-      op.getAttrOfType<IntegerAttr>(ONNXConvOp::getGroupAttrName());
-  if (!groupAttr)
-    op.emitError("group attribute not specified.");
-
-  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/dialect/onnx/onnxop.inc
+++ b/src/dialect/onnx/onnxop.inc
@@ -68,8 +68,8 @@ def ONNXArgMaxOp:ONNX_Op<"ArgMax",
     "The type of the output tensor is integer."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
-           DefaultValuedAttr<I32Attr, "0">:$axis,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "0">:$axis,
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -83,8 +83,8 @@ def ONNXArgMinOp:ONNX_Op<"ArgMin",
     "The type of the output tensor is integer."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
-           DefaultValuedAttr<I32Attr, "0">:$axis,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "0">:$axis,
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -164,8 +164,8 @@ def ONNXAveragePoolOp:ONNX_Op<"AveragePool",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
-           DefaultValuedAttr<I32Attr, "0">:$ceil_mode,
-           DefaultValuedAttr<I32Attr, "0">:$count_include_pad,
+           DefaultValuedAttr<I64Attr, "0">:$ceil_mode,
+           DefaultValuedAttr<I64Attr, "0">:$count_include_pad,
            DefaultValuedAttr<I64ArrayAttr, "{}">:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
@@ -245,7 +245,7 @@ def ONNXCastOp:ONNX_Op<"Cast",
     "an integer 36 to Boolean may produce 1 because we truncate bits which can't be stored in the targeted type."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           DefaultValuedAttr<I32Attr, "0">:$to);
+           DefaultValuedAttr<I64Attr, "0">:$to);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -286,7 +286,7 @@ def ONNXCompressOp:ONNX_Op<"Compress",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$condition,
-           OptionalAttr<I32Attr>:$axis);
+           OptionalAttr<I64Attr>:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -297,7 +297,7 @@ def ONNXConcatOp:ONNX_Op<"Concat",
     "Concatenate a list of tensors into a single tensor. All input tensors must have the same shape, except for the dimension size of the axis to concatenate on."
   }];
   let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$inputs,
-           DefaultValuedAttr<I32Attr, "0">:$axis);
+           DefaultValuedAttr<I64Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -311,8 +311,8 @@ def ONNXConcatFromSequenceOp:ONNX_Op<"ConcatFromSequence",
     "When 'new_axis' is 1, the behavior is similar to numpy.stack."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
-           I32Attr:$axis,
-           DefaultValuedAttr<I32Attr, "0">:$new_axis);
+           I64Attr:$axis,
+           DefaultValuedAttr<I64Attr, "0">:$new_axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -351,7 +351,7 @@ def ONNXConvOp:ONNX_Op<"Conv",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
            DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
            OptionalAttr<I64ArrayAttr>:$dilations,
-           DefaultValuedAttr<I32Attr, "1">:$group,
+           DefaultValuedAttr<I64Attr, "1">:$group,
            OptionalAttr<I64ArrayAttr>:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
@@ -371,7 +371,7 @@ def ONNXConvIntegerOp:ONNX_Op<"ConvInteger",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$w_zero_point,
            DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
            OptionalAttr<I64ArrayAttr>:$dilations,
-           DefaultValuedAttr<I32Attr, "1">:$group,
+           DefaultValuedAttr<I64Attr, "1">:$group,
            OptionalAttr<I64ArrayAttr>:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
@@ -402,7 +402,7 @@ def ONNXConvTransposeOp:ONNX_Op<"ConvTranspose",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
            DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
            OptionalAttr<I64ArrayAttr>:$dilations,
-           DefaultValuedAttr<I32Attr, "1">:$group,
+           DefaultValuedAttr<I64Attr, "1">:$group,
            OptionalAttr<I64ArrayAttr>:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$output_padding,
            OptionalAttr<I64ArrayAttr>:$output_shape,
@@ -458,8 +458,8 @@ def ONNXCumSumOp:ONNX_Op<"CumSum",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$axis,
-           DefaultValuedAttr<I32Attr, "0">:$exclusive,
-           DefaultValuedAttr<I32Attr, "0">:$reverse);
+           DefaultValuedAttr<I64Attr, "0">:$exclusive,
+           DefaultValuedAttr<I64Attr, "0">:$reverse);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -496,7 +496,7 @@ def ONNXDepthToSpaceOp:ONNX_Op<"DepthToSpace",
     ""
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           I32Attr:$blocksize,
+           I64Attr:$blocksize,
            DefaultValuedAttr<StrAttr, "DCR">:$mode);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
@@ -669,8 +669,8 @@ def ONNXEyeLikeOp:ONNX_Op<"EyeLike",
     "TensorProto message and be valid as an output type."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           OptionalAttr<I32Attr>:$dtype,
-           DefaultValuedAttr<I32Attr, "0">:$k);
+           OptionalAttr<I64Attr>:$dtype,
+           DefaultValuedAttr<I64Attr, "0">:$k);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -683,7 +683,7 @@ def ONNXFlattenOp:ONNX_Op<"Flatten",
     "(d_0 X d_1 ... d_(axis-1), d_axis X d_(axis+1) ... X dn)."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           DefaultValuedAttr<I32Attr, "1">:$axis);
+           DefaultValuedAttr<I64Attr, "1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -788,8 +788,8 @@ def ONNXGRUOp:ONNX_Op<"GRU",
            OptionalAttr<StrArrayAttr>:$activations,
            OptionalAttr<F32Attr>:$clip,
            DefaultValuedAttr<StrAttr, "forward">:$direction,
-           OptionalAttr<I32Attr>:$hidden_size,
-           DefaultValuedAttr<I32Attr, "0">:$linear_before_reset);
+           OptionalAttr<I64Attr>:$hidden_size,
+           DefaultValuedAttr<I64Attr, "0">:$linear_before_reset);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -857,7 +857,7 @@ def ONNXGatherOp:ONNX_Op<"Gather",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
-           DefaultValuedAttr<I32Attr, "0">:$axis);
+           DefaultValuedAttr<I64Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -923,7 +923,7 @@ def ONNXGatherElementsOp:ONNX_Op<"GatherElements",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
-           DefaultValuedAttr<I32Attr, "0">:$axis);
+           DefaultValuedAttr<I64Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1025,8 +1025,8 @@ def ONNXGemmOp:ONNX_Op<"Gemm",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$C,
            DefaultValuedAttr<F32Attr, "1.0">:$alpha,
            DefaultValuedAttr<F32Attr, "1.0">:$beta,
-           DefaultValuedAttr<I32Attr, "0">:$transA,
-           DefaultValuedAttr<I32Attr, "0">:$transB);
+           DefaultValuedAttr<I64Attr, "0">:$transA,
+           DefaultValuedAttr<I64Attr, "0">:$transB);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1051,7 +1051,7 @@ def ONNXGlobalLpPoolOp:ONNX_Op<"GlobalLpPool",
     " equal to the spatial dimension of input tensor."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
-           DefaultValuedAttr<I32Attr, "2">:$p);
+           DefaultValuedAttr<I64Attr, "2">:$p);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1115,7 +1115,7 @@ def ONNXHardmaxOp:ONNX_Op<"Hardmax",
     "and contains the hardmax values of the corresponding input."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           DefaultValuedAttr<I32Attr, "1">:$axis);
+           DefaultValuedAttr<I64Attr, "1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1167,8 +1167,8 @@ def ONNXIsInfOp:ONNX_Op<"IsInf",
     "Map infinity to true and other values to false."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
-           DefaultValuedAttr<I32Attr, "1">:$detect_negative,
-           DefaultValuedAttr<I32Attr, "1">:$detect_positive);
+           DefaultValuedAttr<I64Attr, "1">:$detect_negative,
+           DefaultValuedAttr<I64Attr, "1">:$detect_positive);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1201,7 +1201,7 @@ def ONNXLRNOp:ONNX_Op<"LRN",
            DefaultValuedAttr<F32Attr, "0.0001">:$alpha,
            DefaultValuedAttr<F32Attr, "0.75">:$beta,
            DefaultValuedAttr<F32Attr, "1.0">:$bias,
-           I32Attr:$size);
+           I64Attr:$size);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1304,8 +1304,8 @@ def ONNXLSTMOp:ONNX_Op<"LSTM",
            OptionalAttr<StrArrayAttr>:$activations,
            OptionalAttr<F32Attr>:$clip,
            DefaultValuedAttr<StrAttr, "forward">:$direction,
-           OptionalAttr<I32Attr>:$hidden_size,
-           DefaultValuedAttr<I32Attr, "0">:$input_forget);
+           OptionalAttr<I64Attr>:$hidden_size,
+           DefaultValuedAttr<I64Attr, "0">:$input_forget);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1366,7 +1366,7 @@ def ONNXLogSoftmaxOp:ONNX_Op<"LogSoftmax",
     "and contains the logsoftmax values of the corresponding input."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           DefaultValuedAttr<I32Attr, "1">:$axis);
+           DefaultValuedAttr<I64Attr, "1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1522,8 +1522,8 @@ def ONNXLpNormalizationOp:ONNX_Op<"LpNormalization",
     "Given a matrix, apply Lp-normalization along the provided axis."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           DefaultValuedAttr<I32Attr, "-1">:$axis,
-           DefaultValuedAttr<I32Attr, "2">:$p);
+           DefaultValuedAttr<I64Attr, "-1">:$axis,
+           DefaultValuedAttr<I64Attr, "2">:$p);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1540,7 +1540,7 @@ def ONNXLpPoolOp:ONNX_Op<"LpPool",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
            I64ArrayAttr:$kernel_shape,
-           DefaultValuedAttr<I32Attr, "2">:$p,
+           DefaultValuedAttr<I64Attr, "2">:$p,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
@@ -1619,11 +1619,11 @@ def ONNXMaxPoolOp:ONNX_Op<"MaxPool",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
-           DefaultValuedAttr<I32Attr, "0">:$ceil_mode,
+           DefaultValuedAttr<I64Attr, "0">:$ceil_mode,
            OptionalAttr<I64ArrayAttr>:$dilations,
            DefaultValuedAttr<I64ArrayAttr, "{}">:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
-           DefaultValuedAttr<I32Attr, "0">:$storage_order,
+           DefaultValuedAttr<I64Attr, "0">:$storage_order,
            OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
@@ -1731,7 +1731,7 @@ def ONNXModOp:ONNX_Op<"Mod",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
-           DefaultValuedAttr<I32Attr, "0">:$fmod);
+           DefaultValuedAttr<I64Attr, "0">:$fmod);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1756,8 +1756,8 @@ def ONNXMultinomialOp:ONNX_Op<"Multinomial",
     "of each of the possible outcomes."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           DefaultValuedAttr<I32Attr, "6">:$dtype,
-           DefaultValuedAttr<I32Attr, "1">:$sample_size,
+           DefaultValuedAttr<I64Attr, "6">:$dtype,
+           DefaultValuedAttr<I64Attr, "1">:$sample_size,
            OptionalAttr<F32Attr>:$seed);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
@@ -1791,7 +1791,7 @@ def ONNXNonMaxSuppressionOp:ONNX_Op<"NonMaxSuppression",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$max_output_boxes_per_class,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$iou_threshold,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$score_threshold,
-           DefaultValuedAttr<I32Attr, "0">:$center_point_box);
+           DefaultValuedAttr<I64Attr, "0">:$center_point_box);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1845,7 +1845,7 @@ def ONNXOneHotOp:ONNX_Op<"OneHot",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$depth,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$values,
-           DefaultValuedAttr<I32Attr, "-1">:$axis);
+           DefaultValuedAttr<I64Attr, "-1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2005,7 +2005,7 @@ def ONNXQLinearConvOp:ONNX_Op<"QLinearConv",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
            DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
            OptionalAttr<I64ArrayAttr>:$dilations,
-           DefaultValuedAttr<I32Attr, "1">:$group,
+           DefaultValuedAttr<I64Attr, "1">:$group,
            OptionalAttr<I64ArrayAttr>:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
@@ -2127,7 +2127,7 @@ def ONNXRNNOp:ONNX_Op<"RNN",
            DefaultValuedAttr<StrArrayAttr, "{\"Tanh\", \"Tanh\"}">:$activations,
            OptionalAttr<F32Attr>:$clip,
            DefaultValuedAttr<StrAttr, "forward">:$direction,
-           OptionalAttr<I32Attr>:$hidden_size);
+           OptionalAttr<I64Attr>:$hidden_size);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2143,7 +2143,7 @@ def ONNXRandomNormalOp:ONNX_Op<"RandomNormal",
     "be one of the data types specified in the 'DataType' enum field in the"
     "TensorProto message."
   }];
-  let arguments = (ins DefaultValuedAttr<I32Attr, "1">:$dtype,
+  let arguments = (ins DefaultValuedAttr<I64Attr, "1">:$dtype,
            DefaultValuedAttr<F32Attr, "0.0">:$mean,
            DefaultValuedAttr<F32Attr, "1.0">:$scale,
            OptionalAttr<F32Attr>:$seed,
@@ -2164,7 +2164,7 @@ def ONNXRandomNormalLikeOp:ONNX_Op<"RandomNormalLike",
     "TensorProto message, and be valid as an output type."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           OptionalAttr<I32Attr>:$dtype,
+           OptionalAttr<I64Attr>:$dtype,
            DefaultValuedAttr<F32Attr, "0.0">:$mean,
            DefaultValuedAttr<F32Attr, "1.0">:$scale,
            OptionalAttr<F32Attr>:$seed);
@@ -2182,7 +2182,7 @@ def ONNXRandomUniformOp:ONNX_Op<"RandomUniform",
     "be one of the data types specified in the 'DataType' enum field in the"
     "TensorProto message."
   }];
-  let arguments = (ins DefaultValuedAttr<I32Attr, "1">:$dtype,
+  let arguments = (ins DefaultValuedAttr<I64Attr, "1">:$dtype,
            DefaultValuedAttr<F32Attr, "1.0">:$high,
            DefaultValuedAttr<F32Attr, "0.0">:$low,
            OptionalAttr<F32Attr>:$seed,
@@ -2203,7 +2203,7 @@ def ONNXRandomUniformLikeOp:ONNX_Op<"RandomUniformLike",
     "TensorProto message and be valid as an output type."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           OptionalAttr<I32Attr>:$dtype,
+           OptionalAttr<I64Attr>:$dtype,
            DefaultValuedAttr<F32Attr, "1.0">:$high,
            DefaultValuedAttr<F32Attr, "0.0">:$low,
            OptionalAttr<F32Attr>:$seed);
@@ -2271,7 +2271,7 @@ def ONNXReduceL1Op:ONNX_Op<"ReduceL1",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2288,7 +2288,7 @@ def ONNXReduceL2Op:ONNX_Op<"ReduceL2",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2305,7 +2305,7 @@ def ONNXReduceLogSumOp:ONNX_Op<"ReduceLogSum",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2322,7 +2322,7 @@ def ONNXReduceLogSumExpOp:ONNX_Op<"ReduceLogSumExp",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2339,7 +2339,7 @@ def ONNXReduceMaxOp:ONNX_Op<"ReduceMax",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2356,7 +2356,7 @@ def ONNXReduceMeanOp:ONNX_Op<"ReduceMean",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2373,7 +2373,7 @@ def ONNXReduceMinOp:ONNX_Op<"ReduceMin",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2390,7 +2390,7 @@ def ONNXReduceProdOp:ONNX_Op<"ReduceProd",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2407,7 +2407,7 @@ def ONNXReduceSumOp:ONNX_Op<"ReduceSum",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2424,7 +2424,7 @@ def ONNXReduceSumSquareOp:ONNX_Op<"ReduceSumSquare",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2470,7 +2470,7 @@ def ONNXResizeOp:ONNX_Op<"Resize",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$sizes,
            DefaultValuedAttr<StrAttr, "half_pixel">:$coordinate_transformation_mode,
            DefaultValuedAttr<F32Attr, "-0.75">:$cubic_coeff_a,
-           DefaultValuedAttr<I32Attr, "0">:$exclude_outside,
+           DefaultValuedAttr<I64Attr, "0">:$exclude_outside,
            DefaultValuedAttr<F32Attr, "0.0">:$extrapolation_value,
            DefaultValuedAttr<StrAttr, "nearest">:$mode,
            DefaultValuedAttr<StrAttr, "round_prefer_floor">:$nearest_mode);
@@ -2517,8 +2517,8 @@ def ONNXReverseSequenceOp:ONNX_Op<"ReverseSequence",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens,
-           DefaultValuedAttr<I32Attr, "1">:$batch_axis,
-           DefaultValuedAttr<I32Attr, "0">:$time_axis);
+           DefaultValuedAttr<I64Attr, "1">:$batch_axis,
+           DefaultValuedAttr<I64Attr, "0">:$time_axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2542,9 +2542,9 @@ def ONNXRoiAlignOp:ONNX_Op<"RoiAlign",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$rois,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$batch_indices,
            DefaultValuedAttr<StrAttr, "avg">:$mode,
-           DefaultValuedAttr<I32Attr, "1">:$output_height,
-           DefaultValuedAttr<I32Attr, "1">:$output_width,
-           DefaultValuedAttr<I32Attr, "0">:$sampling_ratio,
+           DefaultValuedAttr<I64Attr, "1">:$output_height,
+           DefaultValuedAttr<I64Attr, "1">:$output_width,
+           DefaultValuedAttr<I64Attr, "0">:$sampling_ratio,
            DefaultValuedAttr<F32Attr, "1.0">:$spatial_scale);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
@@ -2699,7 +2699,7 @@ def ONNXScanOp:ONNX_Op<"Scan",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_state_and_scan_inputs,
            AnyAttr:$body,
-           I32Attr:$num_scan_inputs,
+           I64Attr:$num_scan_inputs,
            OptionalAttr<I64ArrayAttr>:$scan_input_axes,
            OptionalAttr<I64ArrayAttr>:$scan_input_directions,
            OptionalAttr<I64ArrayAttr>:$scan_output_axes,
@@ -2768,7 +2768,7 @@ def ONNXScatterOp:ONNX_Op<"Scatter",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates,
-           DefaultValuedAttr<I32Attr, "0">:$axis);
+           DefaultValuedAttr<I64Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2831,7 +2831,7 @@ def ONNXScatterElementsOp:ONNX_Op<"ScatterElements",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates,
-           DefaultValuedAttr<I32Attr, "0">:$axis);
+           DefaultValuedAttr<I64Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2947,7 +2947,7 @@ def ONNXSequenceEmptyOp:ONNX_Op<"SequenceEmpty",
   let description = [{
     "Construct an empty tensor sequence, with given data type."
   }];
-  let arguments = (ins OptionalAttr<I32Attr>:$dtype);
+  let arguments = (ins OptionalAttr<I64Attr>:$dtype);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3136,7 +3136,7 @@ def ONNXSoftmaxOp:ONNX_Op<"Softmax",
     "and contains the softmax values of the corresponding input."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           DefaultValuedAttr<I32Attr, "1">:$axis);
+           DefaultValuedAttr<I64Attr, "1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3171,7 +3171,7 @@ def ONNXSpaceToDepthOp:ONNX_Op<"SpaceToDepth",
     "are moved to the depth dimension."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           I32Attr:$blocksize);
+           I64Attr:$blocksize);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3184,7 +3184,7 @@ def ONNXSplitOp:ONNX_Op<"Split",
     "Otherwise, the tensor is split to equal sized parts."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
-           DefaultValuedAttr<I32Attr, "0">:$axis,
+           DefaultValuedAttr<I64Attr, "0">:$axis,
            OptionalAttr<I64ArrayAttr>:$split);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
@@ -3206,8 +3206,8 @@ def ONNXSplitToSequenceOp:ONNX_Op<"SplitToSequence",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$split,
-           DefaultValuedAttr<I32Attr, "0">:$axis,
-           DefaultValuedAttr<I32Attr, "1">:$keepdims);
+           DefaultValuedAttr<I64Attr, "0">:$axis,
+           DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3253,7 +3253,7 @@ def ONNXStringNormalizerOp:ONNX_Op<"StringNormalizer",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<StrAttr, "NONE">:$case_change_action,
-           DefaultValuedAttr<I32Attr, "0">:$is_case_sensitive,
+           DefaultValuedAttr<I64Attr, "0">:$is_case_sensitive,
            OptionalAttr<StrAttr>:$locale,
            OptionalAttr<StrArrayAttr>:$stopwords);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
@@ -3337,9 +3337,9 @@ def ONNXTfIdfVectorizerOp:ONNX_Op<"TfIdfVectorizer",
     "If pool_strings is set, the input must be a string tensor."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
-           I32Attr:$max_gram_length,
-           I32Attr:$max_skip_count,
-           I32Attr:$min_gram_length,
+           I64Attr:$max_gram_length,
+           I64Attr:$max_skip_count,
+           I64Attr:$min_gram_length,
            StrAttr:$mode,
            I64ArrayAttr:$ngram_counts,
            I64ArrayAttr:$ngram_indexes,
@@ -3396,9 +3396,9 @@ def ONNXTopKOp:ONNX_Op<"TopK",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$K,
-           DefaultValuedAttr<I32Attr, "-1">:$axis,
-           DefaultValuedAttr<I32Attr, "1">:$largest,
-           DefaultValuedAttr<I32Attr, "1">:$sorted);
+           DefaultValuedAttr<I64Attr, "-1">:$axis,
+           DefaultValuedAttr<I64Attr, "1">:$largest,
+           DefaultValuedAttr<I64Attr, "1">:$sorted);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3499,8 +3499,8 @@ def ONNXUniqueOp:ONNX_Op<"Unique",
     "  output_counts = [2 1 1]"
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
-           OptionalAttr<I32Attr>:$axis,
-           DefaultValuedAttr<I32Attr, "1">:$sorted);
+           OptionalAttr<I64Attr>:$axis,
+           DefaultValuedAttr<I64Attr, "1">:$sorted);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 

--- a/src/dialect/onnx/onnxop.inc
+++ b/src/dialect/onnx/onnxop.inc
@@ -39,7 +39,8 @@ def ONNXAddOp:ONNX_Op<"Add",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -52,7 +53,8 @@ def ONNXAndOp:ONNX_Op<"And",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -61,14 +63,13 @@ def ONNXArgMaxOp:ONNX_Op<"ArgMax",
   let summary = "ONNX ArgMax operation";
   let description = [{
     "Computes the indices of the max elements of the input tensor's element along the "
-    "provided axis. The resulting tensor has the same rank as the input if keepdims equal 1. "
-    "If keepdims equal 0, then the resulting tensor have the reduced dimension pruned. "
-    "If select_last_index is True (default False), the index of the last occurence of the max "
-    "is selected if the max appears more than once in the input. Otherwise the index of the "
-    "first occurence is selected."
+    "provided axis. The resulted tensor has the same rank as the input if keepdims equal 1."
+    "If keepdims equal 0, then the resulted tensor have the reduced dimension pruned. "
     "The type of the output tensor is integer."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           DefaultValuedAttr<I32Attr, "0">:$axis,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -77,14 +78,13 @@ def ONNXArgMinOp:ONNX_Op<"ArgMin",
   let summary = "ONNX ArgMin operation";
   let description = [{
     "Computes the indices of the min elements of the input tensor's element along the "
-    "provided axis. The resulting tensor has the same rank as the input if keepdims equal 1. "
-    "If keepdims equal 0, then the resulting tensor have the reduced dimension pruned. "
-    "If select_last_index is True (default False), the index of the last occurence of the min "
-    "is selected if the min appears more than once in the input. Otherwise the index of the "
-    "first occurence is selected."
+    "provided axis. The resulted tensor has the same rank as the input if keepdims equal 1."
+    "If keepdims equal 0, then the resulted tensor have the reduced dimension pruned. "
     "The type of the output tensor is integer."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           DefaultValuedAttr<I32Attr, "0">:$axis,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -162,7 +162,13 @@ def ONNXAveragePoolOp:ONNX_Op<"AveragePool",
     " The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero)."
     " "
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           DefaultValuedAttr<I32Attr, "0">:$ceil_mode,
+           DefaultValuedAttr<I32Attr, "0">:$count_include_pad,
+           DefaultValuedAttr<I64ArrayAttr, "{}">:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -181,7 +187,13 @@ def ONNXBatchNormalizationOp:ONNX_Op<"BatchNormalization",
     "to flatten the input shape to (N x C*D1*D2 ..*Dn) before a BatchNormalization Op."
     "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B, AnyTypeOf<[AnyMemRef, AnyTensor]>:$mean, AnyTypeOf<[AnyMemRef, AnyTensor]>:$var);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$mean,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$var,
+           DefaultValuedAttr<F32Attr, "1e-05">:$epsilon,
+           DefaultValuedAttr<F32Attr, "0.9">:$momentum);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -202,7 +214,9 @@ def ONNXBitShiftOp:ONNX_Op<"BitShift",
     " not necessarily identical."
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y,
+           StrAttr:$direction);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -230,7 +244,8 @@ def ONNXCastOp:ONNX_Op<"Cast",
     "For example, a 64-bit float 3.1415926459 may be round to a 32-bit float 3.141592. Similarly, converting"
     "an integer 36 to Boolean may produce 1 because we truncate bits which can't be stored in the targeted type."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<I32Attr, "0">:$to);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -254,7 +269,9 @@ def ONNXClipOp:ONNX_Op<"Clip",
     "specified by the inputs 'min' and 'max'. They default to"
     "numeric_limits::lowest() and numeric_limits::max(), respectively."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input, AnyTypeOf<[AnyMemRef, AnyTensor]>:$min, AnyTypeOf<[AnyMemRef, AnyTensor]>:$max);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$min,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$max);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -267,7 +284,9 @@ def ONNXCompressOp:ONNX_Op<"Compress",
     "    Compress behaves like numpy.compress: https://docs.scipy.org/doc/numpy/reference/generated/numpy.compress.html"
     "    "
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input, AnyTypeOf<[AnyMemRef, AnyTensor]>:$condition);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$condition,
+           OptionalAttr<I32Attr>:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -277,7 +296,8 @@ def ONNXConcatOp:ONNX_Op<"Concat",
   let description = [{
     "Concatenate a list of tensors into a single tensor. All input tensors must have the same shape, except for the dimension size of the axis to concatenate on."
   }];
-  let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$inputs);
+  let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$inputs,
+           DefaultValuedAttr<I32Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -290,7 +310,9 @@ def ONNXConcatFromSequenceOp:ONNX_Op<"ConcatFromSequence",
     "By default 'new_axis' is 0, the behavior is similar to numpy.concatenate."
     "When 'new_axis' is 1, the behavior is similar to numpy.stack."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
+           I32Attr:$axis,
+           DefaultValuedAttr<I32Attr, "0">:$new_axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -301,7 +323,8 @@ def ONNXConstantOp:ONNX_Op<"Constant",
     "A constant tensor. Exactly one of the two attributes, either value or sparse_value,"
     "must be specified."
   }];
-  let arguments = (ins );
+  let arguments = (ins OptionalAttr<AnyAttr>:$sparse_value,
+           OptionalAttr<AnyAttr>:$value);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -311,18 +334,27 @@ def ONNXConstantOfShapeOp:ONNX_Op<"ConstantOfShape",
   let description = [{
     "Generate a tensor with given value and shape."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           OptionalAttr<AnyAttr>:$value);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
-def ONNXConvOp:ONNX_Op<"Conv",
+def ONNXConvOp:ONNX_Op<"Conv", 
     [NoSideEffect]> {
   let summary = "ONNX Conv operation";
   let description = [{
     "The convolution operator consumes an input tensor and a filter, and"
     "computes the output."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$W, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$W,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           OptionalAttr<I64ArrayAttr>:$dilations,
+           DefaultValuedAttr<I32Attr, "1">:$group,
+           OptionalAttr<I64ArrayAttr>:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -333,7 +365,16 @@ def ONNXConvIntegerOp:ONNX_Op<"ConvInteger",
     "The integer convolution operator consumes an input tensor, its zero-point, a filter, and its zero-point,"
     "and computes the output. The production MUST never overflow. The accumulation may overflow if and only if in 32 bits."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x, AnyTypeOf<[AnyMemRef, AnyTensor]>:$w, AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_zero_point, AnyTypeOf<[AnyMemRef, AnyTensor]>:$w_zero_point);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$w,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_zero_point,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$w_zero_point,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           OptionalAttr<I64ArrayAttr>:$dilations,
+           DefaultValuedAttr<I32Attr, "1">:$group,
+           OptionalAttr<I64ArrayAttr>:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -356,7 +397,17 @@ def ONNXConvTransposeOp:ONNX_Op<"ConvTranspose",
     ""
     "    "
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$W, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$W,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           OptionalAttr<I64ArrayAttr>:$dilations,
+           DefaultValuedAttr<I32Attr, "1">:$group,
+           OptionalAttr<I64ArrayAttr>:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$output_padding,
+           OptionalAttr<I64ArrayAttr>:$output_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -405,7 +456,10 @@ def ONNXCumSumOp:ONNX_Op<"CumSum",
     "```"
     " "
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x, AnyTypeOf<[AnyMemRef, AnyTensor]>:$axis);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$axis,
+           DefaultValuedAttr<I32Attr, "0">:$exclusive,
+           DefaultValuedAttr<I32Attr, "0">:$reverse);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -441,7 +495,9 @@ def ONNXDepthToSpaceOp:ONNX_Op<"DepthToSpace",
     "y = np.reshape(tmp, [b, c // (blocksize ** 2), h * blocksize, w * blocksize])"
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           I32Attr:$blocksize,
+           DefaultValuedAttr<StrAttr, "DCR">:$mode);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -454,7 +510,9 @@ def ONNXDequantizeLinearOp:ONNX_Op<"DequantizeLinear",
     "'x_zero_point' and 'x' must have same type. 'x' and 'y' must have same shape. In the case of dequantizing int32,"
     "there's no zero point (zero point is supposed to be 0)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x, AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_zero_point);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_zero_point);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -480,7 +538,8 @@ def ONNXDivOp:ONNX_Op<"Div",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -495,7 +554,8 @@ def ONNXDropoutOp:ONNX_Op<"Dropout",
     "the training phase, so during testing nothing needs to be done."
     "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           DefaultValuedAttr<F32Attr, "0.5">:$ratio);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -539,7 +599,8 @@ def ONNXEluOp:ONNX_Op<"Elu",
     "0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise."
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<F32Attr, "1.0">:$alpha);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -552,7 +613,8 @@ def ONNXEqualOp:ONNX_Op<"Equal",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -589,7 +651,8 @@ def ONNXExpandOp:ONNX_Op<"Expand",
     "It is possible that the output.shape is not equal to shape, when some dimensions in shape is equal to 1,"
     "or the shape.ndim < input.shape.ndim."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input, AnyTypeOf<[AnyMemRef, AnyTensor]>:$shape);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$shape);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -605,7 +668,9 @@ def ONNXEyeLikeOp:ONNX_Op<"EyeLike",
     "The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the"
     "TensorProto message and be valid as an output type."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           OptionalAttr<I32Attr>:$dtype,
+           DefaultValuedAttr<I32Attr, "0">:$k);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -617,7 +682,8 @@ def ONNXFlattenOp:ONNX_Op<"Flatten",
     "(d_0, d_1, ... d_n) then the output will have shape"
     "(d_0 X d_1 ... d_(axis-1), d_axis X d_(axis+1) ... X dn)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<I32Attr, "1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -711,7 +777,19 @@ def ONNXGRUOp:ONNX_Op<"GRU",
     "  - Ht = (1 - zt) (.) ht + zt (.) Ht-1"
     "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$W, AnyTypeOf<[AnyMemRef, AnyTensor]>:$R, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B, AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens, AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_h);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$W,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$R,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_h,
+           OptionalAttr<F32ArrayAttr>:$activation_alpha,
+           OptionalAttr<F32ArrayAttr>:$activation_beta,
+           OptionalAttr<StrArrayAttr>:$activations,
+           OptionalAttr<F32Attr>:$clip,
+           DefaultValuedAttr<StrAttr, "forward">:$direction,
+           OptionalAttr<I32Attr>:$hidden_size,
+           DefaultValuedAttr<I32Attr, "0">:$linear_before_reset);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -777,7 +855,9 @@ def ONNXGatherOp:ONNX_Op<"Gather",
     "  ]"
     "```"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
+           DefaultValuedAttr<I32Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -841,7 +921,9 @@ def ONNXGatherElementsOp:ONNX_Op<"GatherElements",
     "  ]"
     "```"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
+           DefaultValuedAttr<I32Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -915,7 +997,8 @@ def ONNXGatherNDOp:ONNX_Op<"GatherND",
     "  output  = [[[2,3]],[[4,5]]]             # output_shape = [2, 1, 2] "
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -937,7 +1020,9 @@ def ONNXGemmOp:ONNX_Op<"Gemm",
     "This operator supports **unidirectional broadcasting** (tensor C should be unidirectional broadcastable to tensor A * B); for more details please check [the doc](Broadcasting.md)."
     "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B, AnyTypeOf<[AnyMemRef, AnyTensor]>:$C);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$C);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -961,7 +1046,8 @@ def ONNXGlobalLpPoolOp:ONNX_Op<"GlobalLpPool",
     " the values in the same channel. This is equivalent to LpPool with kernel size"
     " equal to the spatial dimension of input tensor."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<I32Attr, "2">:$p);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -986,7 +1072,8 @@ def ONNXGreaterOp:ONNX_Op<"Greater",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -998,7 +1085,9 @@ def ONNXHardSigmoidOp:ONNX_Op<"HardSigmoid",
     "(Tensor<T>) where the HardSigmoid function, y = max(0, min(1, alpha * x + beta)),"
     "is applied to the tensor elementwise."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<F32Attr, "0.2">:$alpha,
+           DefaultValuedAttr<F32Attr, "0.5">:$beta);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1021,7 +1110,8 @@ def ONNXHardmaxOp:ONNX_Op<"Hardmax",
     "will throw errors. The output tensor has the same shape"
     "and contains the hardmax values of the corresponding input."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<I32Attr, "1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1042,7 +1132,9 @@ def ONNXIfOp:ONNX_Op<"If",
   let description = [{
     "If conditional"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$cond);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$cond,
+           AnyAttr:$else_branch,
+           AnyAttr:$then_branch);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1057,7 +1149,10 @@ def ONNXInstanceNormalizationOp:ONNX_Op<"InstanceNormalization",
     "where mean and variance are computed per instance per channel."
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input, AnyTypeOf<[AnyMemRef, AnyTensor]>:$scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           DefaultValuedAttr<F32Attr, "1e-05">:$epsilon);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1067,7 +1162,9 @@ def ONNXIsInfOp:ONNX_Op<"IsInf",
   let description = [{
     "Map infinity to true and other values to false."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<I32Attr, "1">:$detect_negative,
+           DefaultValuedAttr<I32Attr, "1">:$detect_positive);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1096,7 +1193,11 @@ def ONNXLRNOp:ONNX_Op<"LRN",
     ""
     "Y[n, c, d1, ..., dk] = X[n, c, d1, ..., dk] / (bias + alpha / size * square_sum[n, c, d1, ..., dk] ) ^ beta"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<F32Attr, "0.0001">:$alpha,
+           DefaultValuedAttr<F32Attr, "0.75">:$beta,
+           DefaultValuedAttr<F32Attr, "1.0">:$bias,
+           I32Attr:$size);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1186,7 +1287,21 @@ def ONNXLSTMOp:ONNX_Op<"LSTM",
     "  - Ht = ot (.) h(Ct)"
     "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$W, AnyTypeOf<[AnyMemRef, AnyTensor]>:$R, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B, AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens, AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_h, AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_c, AnyTypeOf<[AnyMemRef, AnyTensor]>:$P);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$W,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$R,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_h,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_c,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$P,
+           OptionalAttr<F32ArrayAttr>:$activation_alpha,
+           OptionalAttr<F32ArrayAttr>:$activation_beta,
+           OptionalAttr<StrArrayAttr>:$activations,
+           OptionalAttr<F32Attr>:$clip,
+           DefaultValuedAttr<StrAttr, "forward">:$direction,
+           OptionalAttr<I32Attr>:$hidden_size,
+           DefaultValuedAttr<I32Attr, "0">:$input_forget);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1198,7 +1313,8 @@ def ONNXLeakyReluOp:ONNX_Op<"LeakyRelu",
     "output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,"
     "`f(x) = x for x >= 0`, is applied to the data tensor elementwise."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<F32Attr, "0.01">:$alpha);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1211,7 +1327,8 @@ def ONNXLessOp:ONNX_Op<"Less",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1244,7 +1361,8 @@ def ONNXLogSoftmaxOp:ONNX_Op<"LogSoftmax",
     "will throw errors. The output tensor has the same shape"
     "and contains the logsoftmax values of the corresponding input."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<I32Attr, "1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1386,7 +1504,10 @@ def ONNXLoopOp:ONNX_Op<"Loop",
     "the scan_outputs from the previous layer, possibly going through several"
     "point-wise operators (e.g. dropout, residual connections, linear layer)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$M, AnyTypeOf<[AnyMemRef, AnyTensor]>:$cond, AnyTypeOf<[AnyMemRef, AnyTensor]>:$v_initial);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$M,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$cond,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$v_initial,
+           AnyAttr:$body);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1396,7 +1517,9 @@ def ONNXLpNormalizationOp:ONNX_Op<"LpNormalization",
   let description = [{
     "Given a matrix, apply Lp-normalization along the provided axis."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<I32Attr, "-1">:$axis,
+           DefaultValuedAttr<I32Attr, "2">:$p);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1410,7 +1533,12 @@ def ONNXLpPoolOp:ONNX_Op<"LpPool",
     " of the input tensor according to the kernel size and downsampling the"
     " data into the output tensor Y for further processing."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           I64ArrayAttr:$kernel_shape,
+           DefaultValuedAttr<I32Attr, "2">:$p,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1420,7 +1548,8 @@ def ONNXMatMulOp:ONNX_Op<"MatMul",
   let description = [{
     "Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1431,7 +1560,10 @@ def ONNXMatMulIntegerOp:ONNX_Op<"MatMulInteger",
     "Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html."
     "The production MUST never overflow. The accumulation may overflow if and only if in 32 bits."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B, AnyTypeOf<[AnyMemRef, AnyTensor]>:$a_zero_point, AnyTypeOf<[AnyMemRef, AnyTensor]>:$b_zero_point);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$a_zero_point,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$b_zero_point);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1481,7 +1613,14 @@ def ONNXMaxPoolOp:ONNX_Op<"MaxPool",
     " The output of each pooling window is maximum number of elements exclude pad."
     " "
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           DefaultValuedAttr<I32Attr, "0">:$ceil_mode,
+           OptionalAttr<I64ArrayAttr>:$dilations,
+           DefaultValuedAttr<I64ArrayAttr, "{}">:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           DefaultValuedAttr<I32Attr, "0">:$storage_order,
+           OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1493,7 +1632,10 @@ def ONNXMaxRoiPoolOp:ONNX_Op<"MaxRoiPool",
     " apply max pooling across each RoI, to produce output 4-D tensor of shape"
     " (num_rois, channels, pooled_shape[0], pooled_shape[1])."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$rois);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$rois,
+           I64ArrayAttr:$pooled_shape,
+           DefaultValuedAttr<F32Attr, "1.0">:$spatial_scale);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1520,7 +1662,12 @@ def ONNXMaxUnpoolOp:ONNX_Op<"MaxUnpool",
     " which define the exact unpooling op. The attributes typically have the same values as the corrsponding"
     " pooling op that the unpooling op is trying to invert."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$I, AnyTypeOf<[AnyMemRef, AnyTensor]>:$output_shape);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$I,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$output_shape,
+           I64ArrayAttr:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1543,7 +1690,8 @@ def ONNXMeanVarianceNormalizationOp:ONNX_Op<"MeanVarianceNormalization",
     "A MeanVarianceNormalization Function: Perform mean variance normalization"
     "      on the input tensor X using formula: <br/> ``` (X-EX)/sqrt(E(X-EX)^2) ```"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<I64ArrayAttr, "{0, 2, 3}">:$axes);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1577,7 +1725,9 @@ def ONNXModOp:ONNX_Op<"Mod",
     ""
     "  This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           DefaultValuedAttr<I32Attr, "0">:$fmod);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1589,7 +1739,8 @@ def ONNXMulOp:ONNX_Op<"Mul",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1600,7 +1751,10 @@ def ONNXMultinomialOp:ONNX_Op<"Multinomial",
     "Generate a tensor of samples from a multinomial distribution according to the probabilities"
     "of each of the possible outcomes."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<I32Attr, "6">:$dtype,
+           DefaultValuedAttr<I32Attr, "1">:$sample_size,
+           OptionalAttr<F32Attr>:$seed);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1628,7 +1782,12 @@ def ONNXNonMaxSuppressionOp:ONNX_Op<"NonMaxSuppression",
     "The selected_indices output is a set of integers indexing into the input collection of bounding boxes representing the selected boxes."
     "The bounding box coordinates corresponding to the selected indices can then be obtained using the Gather or GatherND operation."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$boxes, AnyTypeOf<[AnyMemRef, AnyTensor]>:$scores, AnyTypeOf<[AnyMemRef, AnyTensor]>:$max_output_boxes_per_class, AnyTypeOf<[AnyMemRef, AnyTensor]>:$iou_threshold, AnyTypeOf<[AnyMemRef, AnyTensor]>:$score_threshold);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$boxes,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$scores,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$max_output_boxes_per_class,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$iou_threshold,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$score_threshold,
+           DefaultValuedAttr<I32Attr, "0">:$center_point_box);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1679,7 +1838,10 @@ def ONNXOneHotOp:ONNX_Op<"OneHot",
     "    output[i, j, k, input[i, j, k]] = 1 for all i, j, k and 0 otherwise."
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices, AnyTypeOf<[AnyMemRef, AnyTensor]>:$depth, AnyTypeOf<[AnyMemRef, AnyTensor]>:$values);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$depth,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$values,
+           DefaultValuedAttr<I32Attr, "-1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1692,7 +1854,8 @@ def ONNXOrOp:ONNX_Op<"Or",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1705,7 +1868,8 @@ def ONNXPReluOp:ONNX_Op<"PRelu",
     "`f(x) = x for x >= 0`., is applied to the data tensor elementwise."
     "This operator supports **unidirectional broadcasting** (tensor slope should be unidirectional broadcastable to input tensor X); for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$slope);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$slope);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1795,7 +1959,10 @@ def ONNXPadOp:ONNX_Op<"Pad",
     "  ]"
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$pads, AnyTypeOf<[AnyMemRef, AnyTensor]>:$constant_value);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$pads,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$constant_value,
+           DefaultValuedAttr<StrAttr, "constant">:$mode);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1808,7 +1975,8 @@ def ONNXPowOp:ONNX_Op<"Pow",
     "is applied to the data tensor elementwise."
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1821,10 +1989,22 @@ def ONNXQLinearConvOp:ONNX_Op<"QLinearConv",
     "and computes the quantized output. Each scale and zero-point pair must have same shape."
     "It means they must be either scalars (per tensor) or 1-D tensors (per output channel)."
     "Each input or output and its related zero point must have same type."
-    "When bias is present it must be quantized using scale = input scale * weight scale and "
-    "zero point as 0."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x, AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_zero_point, AnyTypeOf<[AnyMemRef, AnyTensor]>:$w, AnyTypeOf<[AnyMemRef, AnyTensor]>:$w_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$w_zero_point, AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_zero_point, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_zero_point,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$w,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$w_scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$w_zero_point,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_zero_point,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           DefaultValuedAttr<StrAttr, "NOTSET">:$auto_pad,
+           OptionalAttr<I64ArrayAttr>:$dilations,
+           DefaultValuedAttr<I32Attr, "1">:$group,
+           OptionalAttr<I64ArrayAttr>:$kernel_shape,
+           OptionalAttr<I64ArrayAttr>:$pads,
+           OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1841,7 +2021,14 @@ def ONNXQLinearMatMulOp:ONNX_Op<"QLinearMatMul",
     "and the number of elements of scale and zero point tensor of input 'b' should be equal to the number of columns of input 'b'."
     "Production must never overflow, and accumulation may overflow if and only if in 32 bits."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$a, AnyTypeOf<[AnyMemRef, AnyTensor]>:$a_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$a_zero_point, AnyTypeOf<[AnyMemRef, AnyTensor]>:$b, AnyTypeOf<[AnyMemRef, AnyTensor]>:$b_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$b_zero_point, AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_zero_point);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$a,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$a_scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$a_zero_point,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$b,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$b_scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$b_zero_point,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_zero_point);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1853,7 +2040,9 @@ def ONNXQuantizeLinearOp:ONNX_Op<"QuantizeLinear",
     "The quantization formula is y = saturate ((x / y_scale) + y_zero_point). For saturation, it saturates to [0, 255] if it's uint8, or [-128, 127] if it's int8."
     "For (x / y_scale), it's rounding to nearest ties to even. Refer to https://en.wikipedia.org/wiki/Rounding for details. 'y_zero_point' and 'y' must have same type."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x, AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_zero_point);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_scale,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_zero_point);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1923,7 +2112,18 @@ def ONNXRNNOp:ONNX_Op<"RNN",
     "  - Ht = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)"
     "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$W, AnyTypeOf<[AnyMemRef, AnyTensor]>:$R, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B, AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens, AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_h);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$W,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$R,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_h,
+           DefaultValuedAttr<F32ArrayAttr, "{}">:$activation_alpha,
+           DefaultValuedAttr<F32ArrayAttr, "{}">:$activation_beta,
+           DefaultValuedAttr<StrArrayAttr, "{\"Tanh\", \"Tanh\"}">:$activations,
+           OptionalAttr<F32Attr>:$clip,
+           DefaultValuedAttr<StrAttr, "forward">:$direction,
+           OptionalAttr<I32Attr>:$hidden_size);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1939,7 +2139,11 @@ def ONNXRandomNormalOp:ONNX_Op<"RandomNormal",
     "be one of the data types specified in the 'DataType' enum field in the"
     "TensorProto message."
   }];
-  let arguments = (ins );
+  let arguments = (ins DefaultValuedAttr<I32Attr, "1">:$dtype,
+           DefaultValuedAttr<F32Attr, "0.0">:$mean,
+           DefaultValuedAttr<F32Attr, "1.0">:$scale,
+           OptionalAttr<F32Attr>:$seed,
+           I64ArrayAttr:$shape);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1955,7 +2159,11 @@ def ONNXRandomNormalLikeOp:ONNX_Op<"RandomNormalLike",
     "The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the"
     "TensorProto message, and be valid as an output type."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           OptionalAttr<I32Attr>:$dtype,
+           DefaultValuedAttr<F32Attr, "0.0">:$mean,
+           DefaultValuedAttr<F32Attr, "1.0">:$scale,
+           OptionalAttr<F32Attr>:$seed);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1970,7 +2178,11 @@ def ONNXRandomUniformOp:ONNX_Op<"RandomUniform",
     "be one of the data types specified in the 'DataType' enum field in the"
     "TensorProto message."
   }];
-  let arguments = (ins );
+  let arguments = (ins DefaultValuedAttr<I32Attr, "1">:$dtype,
+           DefaultValuedAttr<F32Attr, "1.0">:$high,
+           DefaultValuedAttr<F32Attr, "0.0">:$low,
+           OptionalAttr<F32Attr>:$seed,
+           I64ArrayAttr:$shape);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -1986,7 +2198,11 @@ def ONNXRandomUniformLikeOp:ONNX_Op<"RandomUniformLike",
     "The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the"
     "TensorProto message and be valid as an output type."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           OptionalAttr<I32Attr>:$dtype,
+           DefaultValuedAttr<F32Attr, "1.0">:$high,
+           DefaultValuedAttr<F32Attr, "0.0">:$low,
+           OptionalAttr<F32Attr>:$seed);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2020,7 +2236,9 @@ def ONNXRangeOp:ONNX_Op<"Range",
     "Output: [10, 8, 6]"
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$start, AnyTypeOf<[AnyMemRef, AnyTensor]>:$limit, AnyTypeOf<[AnyMemRef, AnyTensor]>:$delta);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$start,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$limit,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$delta);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2047,7 +2265,9 @@ def ONNXReduceL1Op:ONNX_Op<"ReduceL1",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2062,7 +2282,9 @@ def ONNXReduceL2Op:ONNX_Op<"ReduceL2",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2077,7 +2299,9 @@ def ONNXReduceLogSumOp:ONNX_Op<"ReduceLogSum",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2092,7 +2316,9 @@ def ONNXReduceLogSumExpOp:ONNX_Op<"ReduceLogSumExp",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2107,7 +2333,9 @@ def ONNXReduceMaxOp:ONNX_Op<"ReduceMax",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2122,7 +2350,9 @@ def ONNXReduceMeanOp:ONNX_Op<"ReduceMean",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2137,7 +2367,9 @@ def ONNXReduceMinOp:ONNX_Op<"ReduceMin",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2152,7 +2384,9 @@ def ONNXReduceProdOp:ONNX_Op<"ReduceProd",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2167,7 +2401,9 @@ def ONNXReduceSumOp:ONNX_Op<"ReduceSum",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2182,7 +2418,9 @@ def ONNXReduceSumSquareOp:ONNX_Op<"ReduceSumSquare",
     "The above behavior is similar to numpy, with the exception that numpy default keepdims to"
     "False instead of True."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2209,7 +2447,8 @@ def ONNXReshapeOp:ONNX_Op<"Reshape",
     "could also be 0, in which case the actual dimension value is unchanged (i.e. taken"
     "from the input tensor)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$shape);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$shape);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2221,7 +2460,16 @@ def ONNXResizeOp:ONNX_Op<"Resize",
     "Each dimension value of the output tensor is:"
     "  output_dimension = floor(input_dimension * (roi_end - roi_start) * scale) if input \"sizes\" is not specified."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$roi, AnyTypeOf<[AnyMemRef, AnyTensor]>:$scales, AnyTypeOf<[AnyMemRef, AnyTensor]>:$sizes);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$roi,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$scales,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$sizes,
+           DefaultValuedAttr<StrAttr, "half_pixel">:$coordinate_transformation_mode,
+           DefaultValuedAttr<F32Attr, "-0.75">:$cubic_coeff_a,
+           DefaultValuedAttr<I32Attr, "0">:$exclude_outside,
+           DefaultValuedAttr<F32Attr, "0.0">:$extrapolation_value,
+           DefaultValuedAttr<StrAttr, "nearest">:$mode,
+           DefaultValuedAttr<StrAttr, "round_prefer_floor">:$nearest_mode);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2263,7 +2511,10 @@ def ONNXReverseSequenceOp:ONNX_Op<"ReverseSequence",
     "            [10.0, 9.0,  8.0,  11.0],"
     "            [15.0, 14.0, 13.0, 12.0]]"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input, AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens,
+           DefaultValuedAttr<I32Attr, "1">:$batch_axis,
+           DefaultValuedAttr<I32Attr, "0">:$time_axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2283,7 +2534,14 @@ def ONNXRoiAlignOp:ONNX_Op<"RoiAlign",
     "the value of the sampled locations are computed directly"
     "through bilinear interpolation."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$rois, AnyTypeOf<[AnyMemRef, AnyTensor]>:$batch_indices);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$rois,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$batch_indices,
+           DefaultValuedAttr<StrAttr, "avg">:$mode,
+           DefaultValuedAttr<I32Attr, "1">:$output_height,
+           DefaultValuedAttr<I32Attr, "1">:$output_width,
+           DefaultValuedAttr<I32Attr, "0">:$sampling_ratio,
+           DefaultValuedAttr<F32Attr, "1.0">:$spatial_scale);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2435,7 +2693,13 @@ def ONNXScanOp:ONNX_Op<"Scan",
     "    }"
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_state_and_scan_inputs);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$initial_state_and_scan_inputs,
+           AnyAttr:$body,
+           I32Attr:$num_scan_inputs,
+           OptionalAttr<I64ArrayAttr>:$scan_input_axes,
+           OptionalAttr<I64ArrayAttr>:$scan_input_directions,
+           OptionalAttr<I64ArrayAttr>:$scan_output_axes,
+           OptionalAttr<I64ArrayAttr>:$scan_output_directions);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2497,7 +2761,10 @@ def ONNXScatterOp:ONNX_Op<"Scatter",
     "  output = [[1.0, 1.1, 3.0, 2.1, 5.0]]"
     "```"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices, AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates,
+           DefaultValuedAttr<I32Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2557,7 +2824,10 @@ def ONNXScatterElementsOp:ONNX_Op<"ScatterElements",
     "  output = [[1.0, 1.1, 3.0, 2.1, 5.0]]"
     "```"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices, AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates,
+           DefaultValuedAttr<I32Attr, "0">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2622,7 +2892,9 @@ def ONNXScatterNDOp:ONNX_Op<"ScatterND",
     "             [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]]]"
     "```"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices, AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2635,7 +2907,9 @@ def ONNXSeluOp:ONNX_Op<"Selu",
     "`y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,"
     "is applied to the tensor elementwise."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<F32Attr, "1.67326">:$alpha,
+           DefaultValuedAttr<F32Attr, "1.0507">:$gamma);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2647,7 +2921,8 @@ def ONNXSequenceAtOp:ONNX_Op<"SequenceAt",
     "Accepted range for 'position' is in `[-n, n - 1]`, where `n` is the number of tensors in 'input_sequence'."
     "Negative value means counting positions from the back."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence, AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2668,7 +2943,7 @@ def ONNXSequenceEmptyOp:ONNX_Op<"SequenceEmpty",
   let description = [{
     "Construct an empty tensor sequence, with given data type."
   }];
-  let arguments = (ins );
+  let arguments = (ins OptionalAttr<I32Attr>:$dtype);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2681,7 +2956,8 @@ def ONNXSequenceEraseOp:ONNX_Op<"SequenceErase",
     "Negative value means counting positions from the back."
     "'position' is optional, by default it erases the last tensor from 'input_sequence'."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence, AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2695,7 +2971,9 @@ def ONNXSequenceInsertOp:ONNX_Op<"SequenceInsert",
     "Negative value means counting positions from the back."
     "'position' is optional, by default it inserts 'tensor' to the back of 'input_sequence'."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence, AnyTypeOf<[AnyMemRef, AnyTensor]>:$tensor, AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$tensor,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2728,7 +3006,9 @@ def ONNXShrinkOp:ONNX_Op<"Shrink",
     "bias. The formula of this operator is: If x < -lambd, y = x + bias;"
     "If x > lambd, y = x - bias; Otherwise, y = 0."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<F32Attr, "0.0">:$bias,
+           DefaultValuedAttr<F32Attr, "0.5">:$lambd);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2794,13 +3074,11 @@ def ONNXSliceOp:ONNX_Op<"Slice",
     "Slices uses `starts`, `ends`, `axes` and `steps` inputs to specify the start and end"
     "dimension and step for each axis in the list of axes, it uses this information to"
     "slice the input `data` tensor. If a negative value is passed for any of the"
-    "start or end indices, it represents number of elements before the end of that"
+    "start or end indices, it represent number of elements before the end of that"
     "dimension. If the value passed to start or end is larger than the `n` (the"
     "number of elements in this dimension), it represents `n`. For slicing to the"
-    "end of a dimension with unknown size, it is recommended to pass in `INT_MAX` "
-    "when sclicing forward and 'INT_MIN' when slicing backward."
-    "If a negative value is passed for step, it represents slicing backward. "
-    "However step value cannot be 0."
+    "end of a dimension with unknown size, it is recommended to pass in `INT_MAX`."
+    "If a negative value is passed for step, it represents slicing backward."
     "If `axes` are omitted, they are set to `[0, ..., ndim-1]`."
     "If `steps` are omitted, they are set to `[1, ..., 1]` of length `len(starts)`"
     "Example 1:"
@@ -2826,7 +3104,11 @@ def ONNXSliceOp:ONNX_Op<"Slice",
     "      [2, 3, 4],"
     "  ]"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data, AnyTypeOf<[AnyMemRef, AnyTensor]>:$starts, AnyTypeOf<[AnyMemRef, AnyTensor]>:$ends, AnyTypeOf<[AnyMemRef, AnyTensor]>:$axes, AnyTypeOf<[AnyMemRef, AnyTensor]>:$steps);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$starts,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$ends,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$axes,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$steps);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2849,7 +3131,8 @@ def ONNXSoftmaxOp:ONNX_Op<"Softmax",
     "will throw errors. The output tensor has the same shape"
     "and contains the softmax values of the corresponding input."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<I32Attr, "1">:$axis);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2883,7 +3166,8 @@ def ONNXSpaceToDepthOp:ONNX_Op<"SpaceToDepth",
     "this op outputs a copy of the input tensor where values from the height and width dimensions"
     "are moved to the depth dimension."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           I32Attr:$blocksize);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2895,7 +3179,9 @@ def ONNXSplitOp:ONNX_Op<"Split",
     "'axis'. Lengths of the parts can be specified using argument 'split'."
     "Otherwise, the tensor is split to equal sized parts."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           DefaultValuedAttr<I32Attr, "0">:$axis,
+           OptionalAttr<I64ArrayAttr>:$split);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2914,7 +3200,10 @@ def ONNXSplitToSequenceOp:ONNX_Op<"SplitToSequence",
     "specified in 'split'. In this scenario, the sum of entries in 'split' must be equal to the"
     "dimension size of input tensor on 'axis'."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input, AnyTypeOf<[AnyMemRef, AnyTensor]>:$split);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$split,
+           DefaultValuedAttr<I32Attr, "0">:$axis,
+           DefaultValuedAttr<I32Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2939,7 +3228,8 @@ def ONNXSqueezeOp:ONNX_Op<"Squeeze",
     "If `axes` is not provided, all the single dimensions will be removed from"
     "the shape. If an axis is selected with shape entry not equal to one, an error is raised."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$axes);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2957,7 +3247,11 @@ def ONNXStringNormalizerOp:ONNX_Op<"StringNormalizer",
     "If all elements in X are dropped, the output will be the empty value of string tensor with shape [1]"
     "if input shape is [C] and shape [1, 1] if input shape is [1, C]."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<StrAttr, "NONE">:$case_change_action,
+           DefaultValuedAttr<I32Attr, "0">:$is_case_sensitive,
+           OptionalAttr<StrAttr>:$locale,
+           OptionalAttr<StrArrayAttr>:$stopwords);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -2969,7 +3263,8 @@ def ONNXSubOp:ONNX_Op<"Sub",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3037,7 +3332,16 @@ def ONNXTfIdfVectorizerOp:ONNX_Op<"TfIdfVectorizer",
     "Only one of pool_strings and pool_int64s can be set. If pool_int64s is set, the input should be an integer tensor."
     "If pool_strings is set, the input must be a string tensor."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           I32Attr:$max_gram_length,
+           I32Attr:$max_skip_count,
+           I32Attr:$min_gram_length,
+           StrAttr:$mode,
+           I64ArrayAttr:$ngram_counts,
+           I64ArrayAttr:$ngram_indexes,
+           OptionalAttr<I64ArrayAttr>:$pool_int64s,
+           OptionalAttr<StrArrayAttr>:$pool_strings,
+           OptionalAttr<F32ArrayAttr>:$weights);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3049,7 +3353,8 @@ def ONNXThresholdedReluOp:ONNX_Op<"ThresholdedRelu",
     "(Tensor<T>) where the rectified linear function, y = x for x > alpha, y = 0 otherwise,"
     "is applied to the tensor elementwise."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           DefaultValuedAttr<F32Attr, "1.0">:$alpha);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3061,7 +3366,8 @@ def ONNXTileOp:ONNX_Op<"Tile",
     "This is the same as function `tile` in Numpy, but no broadcast."
     "For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4, 3, 4]]"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input, AnyTypeOf<[AnyMemRef, AnyTensor]>:$repeats);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$repeats);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3084,7 +3390,11 @@ def ONNXTopKOp:ONNX_Op<"TopK",
     "Given two equivalent values, this operator uses the indices along the axis as"
     " a tiebreaker. That is, the element with the lower index will appear first."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$K);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$K,
+           DefaultValuedAttr<I32Attr, "-1">:$axis,
+           DefaultValuedAttr<I32Attr, "1">:$largest,
+           DefaultValuedAttr<I32Attr, "1">:$sorted);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3096,14 +3406,12 @@ def ONNXTransposeOp:ONNX_Op<"Transpose",
     "perm=(1, 0, 2), given an input tensor of shape (1, 2, 3), the output shape"
     "will be (2, 1, 3)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           OptionalAttr<I64ArrayAttr>:$perm);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
-
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = [{ 
     static StringRef getPermAttrName() { return "perm"; }
-  }];
-
-  let verifier = [{ return ::verify(*this); }];
+    }];
 }
 
 def ONNXUniqueOp:ONNX_Op<"Unique", 
@@ -3186,7 +3494,9 @@ def ONNXUniqueOp:ONNX_Op<"Unique",
     ""
     "  output_counts = [2 1 1]"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           OptionalAttr<I32Attr>:$axis,
+           DefaultValuedAttr<I32Attr, "1">:$sorted);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3207,7 +3517,8 @@ def ONNXUnsqueezeOp:ONNX_Op<"Unsqueeze",
     "The order of values in `axes` does not matter and can come in any order. "
     ""
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
+           DefaultValuedAttr<I64ArrayAttr, "{}">:$axes);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3219,7 +3530,9 @@ def ONNXUpsampleOp:ONNX_Op<"Upsample",
     "Each dimension value of the output tensor is:"
     "  output_dimension = floor(input_dimension * scale)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$scales);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$scales,
+           DefaultValuedAttr<StrAttr, "nearest">:$mode);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3232,7 +3545,9 @@ def ONNXWhereOp:ONNX_Op<"Where",
     "    Where behaves like numpy.where with three parameters:"
     "    https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html"
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$condition, AnyTypeOf<[AnyMemRef, AnyTensor]>:$X, AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$condition,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 
@@ -3245,7 +3560,8 @@ def ONNXXorOp:ONNX_Op<"Xor",
     ""
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
-  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A, AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 

--- a/src/dialect/onnx/onnxop.inc
+++ b/src/dialect/onnx/onnxop.inc
@@ -3413,9 +3413,6 @@ def ONNXTransposeOp:ONNX_Op<"Transpose",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$perm);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_transposed);
-  let extraClassDeclaration = [{ 
-    static StringRef getPermAttrName() { return "perm"; }
-    }];
 }
 
 def ONNXUniqueOp:ONNX_Op<"Unique", 

--- a/src/dialect/onnx/onnxop.inc
+++ b/src/dialect/onnx/onnxop.inc
@@ -1022,7 +1022,11 @@ def ONNXGemmOp:ONNX_Op<"Gemm",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
-           AnyTypeOf<[AnyMemRef, AnyTensor]>:$C);
+           AnyTypeOf<[AnyMemRef, AnyTensor]>:$C,
+           DefaultValuedAttr<F32Attr, "1.0">:$alpha,
+           DefaultValuedAttr<F32Attr, "1.0">:$beta,
+           DefaultValuedAttr<I32Attr, "0">:$transA,
+           DefaultValuedAttr<I32Attr, "0">:$transB);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
 }
 

--- a/src/dialect/onnx/onnxop.inc
+++ b/src/dialect/onnx/onnxop.inc
@@ -7,7 +7,7 @@ def ONNXAbsOp:ONNX_Op<"Abs",
     "the tensor elementwise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXAcosOp:ONNX_Op<"Acos", 
@@ -17,7 +17,7 @@ def ONNXAcosOp:ONNX_Op<"Acos",
     "Calculates the arccosine (inverse of cosine) of the given input tensor, element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXAcoshOp:ONNX_Op<"Acosh", 
@@ -27,7 +27,7 @@ def ONNXAcoshOp:ONNX_Op<"Acosh",
     "Calculates the hyperbolic arccosine of the given input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXAddOp:ONNX_Op<"Add", 
@@ -41,7 +41,7 @@ def ONNXAddOp:ONNX_Op<"Add",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXAndOp:ONNX_Op<"And", 
@@ -55,7 +55,7 @@ def ONNXAndOp:ONNX_Op<"And",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXArgMaxOp:ONNX_Op<"ArgMax", 
@@ -70,7 +70,7 @@ def ONNXArgMaxOp:ONNX_Op<"ArgMax",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            DefaultValuedAttr<I64Attr, "0">:$axis,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXArgMinOp:ONNX_Op<"ArgMin", 
@@ -85,7 +85,7 @@ def ONNXArgMinOp:ONNX_Op<"ArgMin",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            DefaultValuedAttr<I64Attr, "0">:$axis,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXAsinOp:ONNX_Op<"Asin", 
@@ -95,7 +95,7 @@ def ONNXAsinOp:ONNX_Op<"Asin",
     "Calculates the arcsine (inverse of sine) of the given input tensor, element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXAsinhOp:ONNX_Op<"Asinh", 
@@ -105,7 +105,7 @@ def ONNXAsinhOp:ONNX_Op<"Asinh",
     "Calculates the hyperbolic arcsine of the given input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXAtanOp:ONNX_Op<"Atan", 
@@ -115,7 +115,7 @@ def ONNXAtanOp:ONNX_Op<"Atan",
     "Calculates the arctangent (inverse of tangent) of the given input tensor, element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXAtanhOp:ONNX_Op<"Atanh", 
@@ -125,7 +125,7 @@ def ONNXAtanhOp:ONNX_Op<"Atanh",
     "Calculates the hyperbolic arctangent of the given input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXAveragePoolOp:ONNX_Op<"AveragePool", 
@@ -169,7 +169,7 @@ def ONNXAveragePoolOp:ONNX_Op<"AveragePool",
            DefaultValuedAttr<I64ArrayAttr, "{}">:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXBatchNormalizationOp:ONNX_Op<"BatchNormalization", 
@@ -194,7 +194,7 @@ def ONNXBatchNormalizationOp:ONNX_Op<"BatchNormalization",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$var,
            DefaultValuedAttr<F32Attr, "1e-05">:$epsilon,
            DefaultValuedAttr<F32Attr, "0.9">:$momentum);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_mean, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_var, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_saved_mean, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_saved_var);
 }
 
 def ONNXBitShiftOp:ONNX_Op<"BitShift", 
@@ -217,7 +217,7 @@ def ONNXBitShiftOp:ONNX_Op<"BitShift",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y,
            StrAttr:$direction);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Z);
 }
 
 def ONNXCastOp:ONNX_Op<"Cast", 
@@ -246,7 +246,7 @@ def ONNXCastOp:ONNX_Op<"Cast",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            DefaultValuedAttr<I64Attr, "0">:$to);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXCeilOp:ONNX_Op<"Ceil", 
@@ -258,7 +258,7 @@ def ONNXCeilOp:ONNX_Op<"Ceil",
     "the tensor elementwise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXClipOp:ONNX_Op<"Clip", 
@@ -272,7 +272,7 @@ def ONNXClipOp:ONNX_Op<"Clip",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$min,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$max);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXCompressOp:ONNX_Op<"Compress", 
@@ -287,7 +287,7 @@ def ONNXCompressOp:ONNX_Op<"Compress",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$condition,
            OptionalAttr<I64Attr>:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXConcatOp:ONNX_Op<"Concat", 
@@ -298,7 +298,7 @@ def ONNXConcatOp:ONNX_Op<"Concat",
   }];
   let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$inputs,
            DefaultValuedAttr<I64Attr, "0">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_concat_result);
 }
 
 def ONNXConcatFromSequenceOp:ONNX_Op<"ConcatFromSequence", 
@@ -313,7 +313,7 @@ def ONNXConcatFromSequenceOp:ONNX_Op<"ConcatFromSequence",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
            I64Attr:$axis,
            DefaultValuedAttr<I64Attr, "0">:$new_axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_concat_result);
 }
 
 def ONNXConstantOp:ONNX_Op<"Constant", 
@@ -325,7 +325,7 @@ def ONNXConstantOp:ONNX_Op<"Constant",
   }];
   let arguments = (ins OptionalAttr<AnyAttr>:$sparse_value,
            OptionalAttr<AnyAttr>:$value);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXConstantOfShapeOp:ONNX_Op<"ConstantOfShape", 
@@ -336,7 +336,7 @@ def ONNXConstantOfShapeOp:ONNX_Op<"ConstantOfShape",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            OptionalAttr<AnyAttr>:$value);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXConvOp:ONNX_Op<"Conv", 
@@ -355,7 +355,7 @@ def ONNXConvOp:ONNX_Op<"Conv",
            OptionalAttr<I64ArrayAttr>:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXConvIntegerOp:ONNX_Op<"ConvInteger", 
@@ -375,7 +375,7 @@ def ONNXConvIntegerOp:ONNX_Op<"ConvInteger",
            OptionalAttr<I64ArrayAttr>:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y);
 }
 
 def ONNXConvTransposeOp:ONNX_Op<"ConvTranspose", 
@@ -408,7 +408,7 @@ def ONNXConvTransposeOp:ONNX_Op<"ConvTranspose",
            OptionalAttr<I64ArrayAttr>:$output_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXCosOp:ONNX_Op<"Cos", 
@@ -418,7 +418,7 @@ def ONNXCosOp:ONNX_Op<"Cos",
     "Calculates the cosine of the given input tensor, element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXCoshOp:ONNX_Op<"Cosh", 
@@ -428,7 +428,7 @@ def ONNXCoshOp:ONNX_Op<"Cosh",
     "Calculates the hyperbolic cosine of the given input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXCumSumOp:ONNX_Op<"CumSum", 
@@ -460,7 +460,7 @@ def ONNXCumSumOp:ONNX_Op<"CumSum",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$axis,
            DefaultValuedAttr<I64Attr, "0">:$exclusive,
            DefaultValuedAttr<I64Attr, "0">:$reverse);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y);
 }
 
 def ONNXDepthToSpaceOp:ONNX_Op<"DepthToSpace", 
@@ -498,7 +498,7 @@ def ONNXDepthToSpaceOp:ONNX_Op<"DepthToSpace",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            I64Attr:$blocksize,
            DefaultValuedAttr<StrAttr, "DCR">:$mode);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXDequantizeLinearOp:ONNX_Op<"DequantizeLinear", 
@@ -513,7 +513,7 @@ def ONNXDequantizeLinearOp:ONNX_Op<"DequantizeLinear",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_scale,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$x_zero_point);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y);
 }
 
 def ONNXDetOp:ONNX_Op<"Det", 
@@ -527,7 +527,7 @@ def ONNXDetOp:ONNX_Op<"Det",
     "e.g., When the input is 2-D, the output is a scalar(shape is empty: `[]`)."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXDivOp:ONNX_Op<"Div", 
@@ -540,7 +540,7 @@ def ONNXDivOp:ONNX_Op<"Div",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXDropoutOp:ONNX_Op<"Dropout", 
@@ -556,7 +556,7 @@ def ONNXDropoutOp:ONNX_Op<"Dropout",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            DefaultValuedAttr<F32Attr, "0.5">:$ratio);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_mask);
 }
 
 def ONNXDynamicQuantizeLinearOp:ONNX_Op<"DynamicQuantizeLinear", 
@@ -587,7 +587,7 @@ def ONNXDynamicQuantizeLinearOp:ONNX_Op<"DynamicQuantizeLinear",
     "```"
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y_scale, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y_zero_point);
 }
 
 def ONNXEluOp:ONNX_Op<"Elu", 
@@ -601,7 +601,7 @@ def ONNXEluOp:ONNX_Op<"Elu",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<F32Attr, "1.0">:$alpha);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXEqualOp:ONNX_Op<"Equal", 
@@ -615,7 +615,7 @@ def ONNXEqualOp:ONNX_Op<"Equal",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXErfOp:ONNX_Op<"Erf", 
@@ -625,7 +625,7 @@ def ONNXErfOp:ONNX_Op<"Erf",
     "Computes the error function of the given input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXExpOp:ONNX_Op<"Exp", 
@@ -635,7 +635,7 @@ def ONNXExpOp:ONNX_Op<"Exp",
     "Calculates the exponential of the given input tensor, element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXExpandOp:ONNX_Op<"Expand", 
@@ -653,7 +653,7 @@ def ONNXExpandOp:ONNX_Op<"Expand",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$shape);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXEyeLikeOp:ONNX_Op<"EyeLike", 
@@ -671,7 +671,7 @@ def ONNXEyeLikeOp:ONNX_Op<"EyeLike",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            OptionalAttr<I64Attr>:$dtype,
            DefaultValuedAttr<I64Attr, "0">:$k);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXFlattenOp:ONNX_Op<"Flatten", 
@@ -684,7 +684,7 @@ def ONNXFlattenOp:ONNX_Op<"Flatten",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            DefaultValuedAttr<I64Attr, "1">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXFloorOp:ONNX_Op<"Floor", 
@@ -696,7 +696,7 @@ def ONNXFloorOp:ONNX_Op<"Floor",
     "the tensor elementwise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXGRUOp:ONNX_Op<"GRU", 
@@ -790,7 +790,7 @@ def ONNXGRUOp:ONNX_Op<"GRU",
            DefaultValuedAttr<StrAttr, "forward">:$direction,
            OptionalAttr<I64Attr>:$hidden_size,
            DefaultValuedAttr<I64Attr, "0">:$linear_before_reset);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y_h);
 }
 
 def ONNXGatherOp:ONNX_Op<"Gather", 
@@ -858,7 +858,7 @@ def ONNXGatherOp:ONNX_Op<"Gather",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
            DefaultValuedAttr<I64Attr, "0">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXGatherElementsOp:ONNX_Op<"GatherElements", 
@@ -924,7 +924,7 @@ def ONNXGatherElementsOp:ONNX_Op<"GatherElements",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
            DefaultValuedAttr<I64Attr, "0">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXGatherNDOp:ONNX_Op<"GatherND", 
@@ -999,7 +999,7 @@ def ONNXGatherNDOp:ONNX_Op<"GatherND",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXGemmOp:ONNX_Op<"Gemm", 
@@ -1027,7 +1027,7 @@ def ONNXGemmOp:ONNX_Op<"Gemm",
            DefaultValuedAttr<F32Attr, "1.0">:$beta,
            DefaultValuedAttr<I64Attr, "0">:$transA,
            DefaultValuedAttr<I64Attr, "0">:$transB);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXGlobalAveragePoolOp:ONNX_Op<"GlobalAveragePool", 
@@ -1039,7 +1039,7 @@ def ONNXGlobalAveragePoolOp:ONNX_Op<"GlobalAveragePool",
     " equal to the spatial dimension of input tensor."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXGlobalLpPoolOp:ONNX_Op<"GlobalLpPool", 
@@ -1052,7 +1052,7 @@ def ONNXGlobalLpPoolOp:ONNX_Op<"GlobalLpPool",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<I64Attr, "2">:$p);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXGlobalMaxPoolOp:ONNX_Op<"GlobalMaxPool", 
@@ -1064,7 +1064,7 @@ def ONNXGlobalMaxPoolOp:ONNX_Op<"GlobalMaxPool",
     " equal to the spatial dimension of input tensor."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXGreaterOp:ONNX_Op<"Greater", 
@@ -1078,7 +1078,7 @@ def ONNXGreaterOp:ONNX_Op<"Greater",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXHardSigmoidOp:ONNX_Op<"HardSigmoid", 
@@ -1092,7 +1092,7 @@ def ONNXHardSigmoidOp:ONNX_Op<"HardSigmoid",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<F32Attr, "0.2">:$alpha,
            DefaultValuedAttr<F32Attr, "0.5">:$beta);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXHardmaxOp:ONNX_Op<"Hardmax", 
@@ -1116,7 +1116,7 @@ def ONNXHardmaxOp:ONNX_Op<"Hardmax",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            DefaultValuedAttr<I64Attr, "1">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXIdentityOp:ONNX_Op<"Identity", 
@@ -1127,7 +1127,7 @@ def ONNXIdentityOp:ONNX_Op<"Identity",
     "Identity operator"
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXIfOp:ONNX_Op<"If", 
@@ -1139,7 +1139,7 @@ def ONNXIfOp:ONNX_Op<"If",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$cond,
            AnyAttr:$else_branch,
            AnyAttr:$then_branch);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_outputs);
 }
 
 def ONNXInstanceNormalizationOp:ONNX_Op<"InstanceNormalization", 
@@ -1157,7 +1157,7 @@ def ONNXInstanceNormalizationOp:ONNX_Op<"InstanceNormalization",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$scale,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
            DefaultValuedAttr<F32Attr, "1e-05">:$epsilon);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXIsInfOp:ONNX_Op<"IsInf", 
@@ -1169,7 +1169,7 @@ def ONNXIsInfOp:ONNX_Op<"IsInf",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<I64Attr, "1">:$detect_negative,
            DefaultValuedAttr<I64Attr, "1">:$detect_positive);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXIsNaNOp:ONNX_Op<"IsNaN", 
@@ -1179,7 +1179,7 @@ def ONNXIsNaNOp:ONNX_Op<"IsNaN",
     "Returns which elements of the input are NaN."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXLRNOp:ONNX_Op<"LRN", 
@@ -1202,7 +1202,7 @@ def ONNXLRNOp:ONNX_Op<"LRN",
            DefaultValuedAttr<F32Attr, "0.75">:$beta,
            DefaultValuedAttr<F32Attr, "1.0">:$bias,
            I64Attr:$size);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXLSTMOp:ONNX_Op<"LSTM", 
@@ -1306,7 +1306,7 @@ def ONNXLSTMOp:ONNX_Op<"LSTM",
            DefaultValuedAttr<StrAttr, "forward">:$direction,
            OptionalAttr<I64Attr>:$hidden_size,
            DefaultValuedAttr<I64Attr, "0">:$input_forget);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y_h, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y_c);
 }
 
 def ONNXLeakyReluOp:ONNX_Op<"LeakyRelu", 
@@ -1319,7 +1319,7 @@ def ONNXLeakyReluOp:ONNX_Op<"LeakyRelu",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<F32Attr, "0.01">:$alpha);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXLessOp:ONNX_Op<"Less", 
@@ -1333,7 +1333,7 @@ def ONNXLessOp:ONNX_Op<"Less",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXLogOp:ONNX_Op<"Log", 
@@ -1343,7 +1343,7 @@ def ONNXLogOp:ONNX_Op<"Log",
     "Calculates the natural log of the given input tensor, element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXLogSoftmaxOp:ONNX_Op<"LogSoftmax", 
@@ -1367,7 +1367,7 @@ def ONNXLogSoftmaxOp:ONNX_Op<"LogSoftmax",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            DefaultValuedAttr<I64Attr, "1">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXLoopOp:ONNX_Op<"Loop", 
@@ -1512,7 +1512,7 @@ def ONNXLoopOp:ONNX_Op<"Loop",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$cond,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$v_initial,
            AnyAttr:$body);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_v_final_and_scan_outputs);
 }
 
 def ONNXLpNormalizationOp:ONNX_Op<"LpNormalization", 
@@ -1524,7 +1524,7 @@ def ONNXLpNormalizationOp:ONNX_Op<"LpNormalization",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            DefaultValuedAttr<I64Attr, "-1">:$axis,
            DefaultValuedAttr<I64Attr, "2">:$p);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXLpPoolOp:ONNX_Op<"LpPool", 
@@ -1543,7 +1543,7 @@ def ONNXLpPoolOp:ONNX_Op<"LpPool",
            DefaultValuedAttr<I64Attr, "2">:$p,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXMatMulOp:ONNX_Op<"MatMul", 
@@ -1554,7 +1554,7 @@ def ONNXMatMulOp:ONNX_Op<"MatMul",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXMatMulIntegerOp:ONNX_Op<"MatMulInteger", 
@@ -1568,7 +1568,7 @@ def ONNXMatMulIntegerOp:ONNX_Op<"MatMulInteger",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$a_zero_point,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$b_zero_point);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXMaxOp:ONNX_Op<"Max", 
@@ -1580,7 +1580,7 @@ def ONNXMaxOp:ONNX_Op<"Max",
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
   let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$data_0);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_max);
 }
 
 def ONNXMaxPoolOp:ONNX_Op<"MaxPool", 
@@ -1625,7 +1625,7 @@ def ONNXMaxPoolOp:ONNX_Op<"MaxPool",
            OptionalAttr<I64ArrayAttr>:$pads,
            DefaultValuedAttr<I64Attr, "0">:$storage_order,
            OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Indices);
 }
 
 def ONNXMaxRoiPoolOp:ONNX_Op<"MaxRoiPool", 
@@ -1640,7 +1640,7 @@ def ONNXMaxRoiPoolOp:ONNX_Op<"MaxRoiPool",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$rois,
            I64ArrayAttr:$pooled_shape,
            DefaultValuedAttr<F32Attr, "1.0">:$spatial_scale);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXMaxUnpoolOp:ONNX_Op<"MaxUnpool", 
@@ -1672,7 +1672,7 @@ def ONNXMaxUnpoolOp:ONNX_Op<"MaxUnpool",
            I64ArrayAttr:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXMeanOp:ONNX_Op<"Mean", 
@@ -1684,7 +1684,7 @@ def ONNXMeanOp:ONNX_Op<"Mean",
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
   let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$data_0);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_mean);
 }
 
 def ONNXMeanVarianceNormalizationOp:ONNX_Op<"MeanVarianceNormalization", 
@@ -1696,7 +1696,7 @@ def ONNXMeanVarianceNormalizationOp:ONNX_Op<"MeanVarianceNormalization",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<I64ArrayAttr, "{0, 2, 3}">:$axes);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXMinOp:ONNX_Op<"Min", 
@@ -1708,7 +1708,7 @@ def ONNXMinOp:ONNX_Op<"Min",
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
   let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$data_0);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_min);
 }
 
 def ONNXModOp:ONNX_Op<"Mod", 
@@ -1732,7 +1732,7 @@ def ONNXModOp:ONNX_Op<"Mod",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
            DefaultValuedAttr<I64Attr, "0">:$fmod);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXMulOp:ONNX_Op<"Mul", 
@@ -1745,7 +1745,7 @@ def ONNXMulOp:ONNX_Op<"Mul",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXMultinomialOp:ONNX_Op<"Multinomial", 
@@ -1759,7 +1759,7 @@ def ONNXMultinomialOp:ONNX_Op<"Multinomial",
            DefaultValuedAttr<I64Attr, "6">:$dtype,
            DefaultValuedAttr<I64Attr, "1">:$sample_size,
            OptionalAttr<F32Attr>:$seed);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXNegOp:ONNX_Op<"Neg", 
@@ -1771,7 +1771,7 @@ def ONNXNegOp:ONNX_Op<"Neg",
     "the tensor elementwise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXNonMaxSuppressionOp:ONNX_Op<"NonMaxSuppression", 
@@ -1792,7 +1792,7 @@ def ONNXNonMaxSuppressionOp:ONNX_Op<"NonMaxSuppression",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$iou_threshold,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$score_threshold,
            DefaultValuedAttr<I64Attr, "0">:$center_point_box);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_selected_indices);
 }
 
 def ONNXNonZeroOp:ONNX_Op<"NonZero", 
@@ -1805,7 +1805,7 @@ def ONNXNonZeroOp:ONNX_Op<"NonZero",
     "    https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html"
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXNotOp:ONNX_Op<"Not", 
@@ -1815,7 +1815,7 @@ def ONNXNotOp:ONNX_Op<"Not",
     "Returns the negation of the input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXOneHotOp:ONNX_Op<"OneHot", 
@@ -1846,7 +1846,7 @@ def ONNXOneHotOp:ONNX_Op<"OneHot",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$depth,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$values,
            DefaultValuedAttr<I64Attr, "-1">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXOrOp:ONNX_Op<"Or", 
@@ -1860,7 +1860,7 @@ def ONNXOrOp:ONNX_Op<"Or",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXPReluOp:ONNX_Op<"PRelu", 
@@ -1874,7 +1874,7 @@ def ONNXPReluOp:ONNX_Op<"PRelu",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$slope);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXPadOp:ONNX_Op<"Pad", 
@@ -1967,7 +1967,7 @@ def ONNXPadOp:ONNX_Op<"Pad",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$pads,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$constant_value,
            DefaultValuedAttr<StrAttr, "constant">:$mode);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXPowOp:ONNX_Op<"Pow", 
@@ -1981,7 +1981,7 @@ def ONNXPowOp:ONNX_Op<"Pow",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Z);
 }
 
 def ONNXQLinearConvOp:ONNX_Op<"QLinearConv", 
@@ -2009,7 +2009,7 @@ def ONNXQLinearConvOp:ONNX_Op<"QLinearConv",
            OptionalAttr<I64ArrayAttr>:$kernel_shape,
            OptionalAttr<I64ArrayAttr>:$pads,
            OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y);
 }
 
 def ONNXQLinearMatMulOp:ONNX_Op<"QLinearMatMul", 
@@ -2033,7 +2033,7 @@ def ONNXQLinearMatMulOp:ONNX_Op<"QLinearMatMul",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$b_zero_point,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_scale,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_zero_point);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y);
 }
 
 def ONNXQuantizeLinearOp:ONNX_Op<"QuantizeLinear", 
@@ -2047,7 +2047,7 @@ def ONNXQuantizeLinearOp:ONNX_Op<"QuantizeLinear",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$x,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_scale,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$y_zero_point);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_y);
 }
 
 def ONNXRNNOp:ONNX_Op<"RNN", 
@@ -2128,7 +2128,7 @@ def ONNXRNNOp:ONNX_Op<"RNN",
            OptionalAttr<F32Attr>:$clip,
            DefaultValuedAttr<StrAttr, "forward">:$direction,
            OptionalAttr<I64Attr>:$hidden_size);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y_h);
 }
 
 def ONNXRandomNormalOp:ONNX_Op<"RandomNormal", 
@@ -2148,7 +2148,7 @@ def ONNXRandomNormalOp:ONNX_Op<"RandomNormal",
            DefaultValuedAttr<F32Attr, "1.0">:$scale,
            OptionalAttr<F32Attr>:$seed,
            I64ArrayAttr:$shape);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXRandomNormalLikeOp:ONNX_Op<"RandomNormalLike", 
@@ -2168,7 +2168,7 @@ def ONNXRandomNormalLikeOp:ONNX_Op<"RandomNormalLike",
            DefaultValuedAttr<F32Attr, "0.0">:$mean,
            DefaultValuedAttr<F32Attr, "1.0">:$scale,
            OptionalAttr<F32Attr>:$seed);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXRandomUniformOp:ONNX_Op<"RandomUniform", 
@@ -2187,7 +2187,7 @@ def ONNXRandomUniformOp:ONNX_Op<"RandomUniform",
            DefaultValuedAttr<F32Attr, "0.0">:$low,
            OptionalAttr<F32Attr>:$seed,
            I64ArrayAttr:$shape);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXRandomUniformLikeOp:ONNX_Op<"RandomUniformLike", 
@@ -2207,7 +2207,7 @@ def ONNXRandomUniformLikeOp:ONNX_Op<"RandomUniformLike",
            DefaultValuedAttr<F32Attr, "1.0">:$high,
            DefaultValuedAttr<F32Attr, "0.0">:$low,
            OptionalAttr<F32Attr>:$seed);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXRangeOp:ONNX_Op<"Range", 
@@ -2243,7 +2243,7 @@ def ONNXRangeOp:ONNX_Op<"Range",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$start,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$limit,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$delta);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXReciprocalOp:ONNX_Op<"Reciprocal", 
@@ -2255,7 +2255,7 @@ def ONNXReciprocalOp:ONNX_Op<"Reciprocal",
     "the tensor elementwise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXReduceL1Op:ONNX_Op<"ReduceL1", 
@@ -2272,7 +2272,7 @@ def ONNXReduceL1Op:ONNX_Op<"ReduceL1",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceL2Op:ONNX_Op<"ReduceL2", 
@@ -2289,7 +2289,7 @@ def ONNXReduceL2Op:ONNX_Op<"ReduceL2",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceLogSumOp:ONNX_Op<"ReduceLogSum", 
@@ -2306,7 +2306,7 @@ def ONNXReduceLogSumOp:ONNX_Op<"ReduceLogSum",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceLogSumExpOp:ONNX_Op<"ReduceLogSumExp", 
@@ -2323,7 +2323,7 @@ def ONNXReduceLogSumExpOp:ONNX_Op<"ReduceLogSumExp",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceMaxOp:ONNX_Op<"ReduceMax", 
@@ -2340,7 +2340,7 @@ def ONNXReduceMaxOp:ONNX_Op<"ReduceMax",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceMeanOp:ONNX_Op<"ReduceMean", 
@@ -2357,7 +2357,7 @@ def ONNXReduceMeanOp:ONNX_Op<"ReduceMean",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceMinOp:ONNX_Op<"ReduceMin", 
@@ -2374,7 +2374,7 @@ def ONNXReduceMinOp:ONNX_Op<"ReduceMin",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceProdOp:ONNX_Op<"ReduceProd", 
@@ -2391,7 +2391,7 @@ def ONNXReduceProdOp:ONNX_Op<"ReduceProd",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceSumOp:ONNX_Op<"ReduceSum", 
@@ -2408,7 +2408,7 @@ def ONNXReduceSumOp:ONNX_Op<"ReduceSum",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReduceSumSquareOp:ONNX_Op<"ReduceSumSquare", 
@@ -2425,7 +2425,7 @@ def ONNXReduceSumSquareOp:ONNX_Op<"ReduceSumSquare",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reduced);
 }
 
 def ONNXReluOp:ONNX_Op<"Relu", 
@@ -2437,7 +2437,7 @@ def ONNXReluOp:ONNX_Op<"Relu",
     "the tensor elementwise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXReshapeOp:ONNX_Op<"Reshape", 
@@ -2453,7 +2453,7 @@ def ONNXReshapeOp:ONNX_Op<"Reshape",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$shape);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_reshaped);
 }
 
 def ONNXResizeOp:ONNX_Op<"Resize", 
@@ -2474,7 +2474,7 @@ def ONNXResizeOp:ONNX_Op<"Resize",
            DefaultValuedAttr<F32Attr, "0.0">:$extrapolation_value,
            DefaultValuedAttr<StrAttr, "nearest">:$mode,
            DefaultValuedAttr<StrAttr, "round_prefer_floor">:$nearest_mode);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXReverseSequenceOp:ONNX_Op<"ReverseSequence", 
@@ -2519,7 +2519,7 @@ def ONNXReverseSequenceOp:ONNX_Op<"ReverseSequence",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$sequence_lens,
            DefaultValuedAttr<I64Attr, "1">:$batch_axis,
            DefaultValuedAttr<I64Attr, "0">:$time_axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXRoiAlignOp:ONNX_Op<"RoiAlign", 
@@ -2546,7 +2546,7 @@ def ONNXRoiAlignOp:ONNX_Op<"RoiAlign",
            DefaultValuedAttr<I64Attr, "1">:$output_width,
            DefaultValuedAttr<I64Attr, "0">:$sampling_ratio,
            DefaultValuedAttr<F32Attr, "1.0">:$spatial_scale);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXRoundOp:ONNX_Op<"Round", 
@@ -2568,7 +2568,7 @@ def ONNXRoundOp:ONNX_Op<"Round",
     "```"
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXScanOp:ONNX_Op<"Scan", 
@@ -2704,7 +2704,7 @@ def ONNXScanOp:ONNX_Op<"Scan",
            OptionalAttr<I64ArrayAttr>:$scan_input_directions,
            OptionalAttr<I64ArrayAttr>:$scan_output_axes,
            OptionalAttr<I64ArrayAttr>:$scan_output_directions);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_final_state_and_scan_outputs);
 }
 
 def ONNXScatterOp:ONNX_Op<"Scatter", 
@@ -2769,7 +2769,7 @@ def ONNXScatterOp:ONNX_Op<"Scatter",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates,
            DefaultValuedAttr<I64Attr, "0">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXScatterElementsOp:ONNX_Op<"ScatterElements", 
@@ -2832,7 +2832,7 @@ def ONNXScatterElementsOp:ONNX_Op<"ScatterElements",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates,
            DefaultValuedAttr<I64Attr, "0">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXScatterNDOp:ONNX_Op<"ScatterND", 
@@ -2899,7 +2899,7 @@ def ONNXScatterNDOp:ONNX_Op<"ScatterND",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$indices,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$updates);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSeluOp:ONNX_Op<"Selu", 
@@ -2914,7 +2914,7 @@ def ONNXSeluOp:ONNX_Op<"Selu",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<F32Attr, "1.67326">:$alpha,
            DefaultValuedAttr<F32Attr, "1.0507">:$gamma);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXSequenceAtOp:ONNX_Op<"SequenceAt", 
@@ -2927,7 +2927,7 @@ def ONNXSequenceAtOp:ONNX_Op<"SequenceAt",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_tensor);
 }
 
 def ONNXSequenceConstructOp:ONNX_Op<"SequenceConstruct", 
@@ -2938,7 +2938,7 @@ def ONNXSequenceConstructOp:ONNX_Op<"SequenceConstruct",
     "All tensors in 'inputs' must have the same data type."
   }];
   let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$inputs);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output_sequence);
 }
 
 def ONNXSequenceEmptyOp:ONNX_Op<"SequenceEmpty", 
@@ -2948,7 +2948,7 @@ def ONNXSequenceEmptyOp:ONNX_Op<"SequenceEmpty",
     "Construct an empty tensor sequence, with given data type."
   }];
   let arguments = (ins OptionalAttr<I64Attr>:$dtype);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSequenceEraseOp:ONNX_Op<"SequenceErase", 
@@ -2962,7 +2962,7 @@ def ONNXSequenceEraseOp:ONNX_Op<"SequenceErase",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output_sequence);
 }
 
 def ONNXSequenceInsertOp:ONNX_Op<"SequenceInsert", 
@@ -2978,7 +2978,7 @@ def ONNXSequenceInsertOp:ONNX_Op<"SequenceInsert",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$tensor,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$position);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output_sequence);
 }
 
 def ONNXSequenceLengthOp:ONNX_Op<"SequenceLength", 
@@ -2988,7 +2988,7 @@ def ONNXSequenceLengthOp:ONNX_Op<"SequenceLength",
     "Produces a scalar(tensor of empty shape) containing the number of tensors in 'input_sequence'."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input_sequence);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_length);
 }
 
 def ONNXShapeOp:ONNX_Op<"Shape", 
@@ -2998,7 +2998,7 @@ def ONNXShapeOp:ONNX_Op<"Shape",
     "Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_shape);
 }
 
 def ONNXShrinkOp:ONNX_Op<"Shrink", 
@@ -3013,7 +3013,7 @@ def ONNXShrinkOp:ONNX_Op<"Shrink",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            DefaultValuedAttr<F32Attr, "0.0">:$bias,
            DefaultValuedAttr<F32Attr, "0.5">:$lambd);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSigmoidOp:ONNX_Op<"Sigmoid", 
@@ -3025,7 +3025,7 @@ def ONNXSigmoidOp:ONNX_Op<"Sigmoid",
     "tensor elementwise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXSignOp:ONNX_Op<"Sign", 
@@ -3036,7 +3036,7 @@ def ONNXSignOp:ONNX_Op<"Sign",
     "If input > 0, output 1. if input < 0, output -1. if input == 0, output 0."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSinOp:ONNX_Op<"Sin", 
@@ -3046,7 +3046,7 @@ def ONNXSinOp:ONNX_Op<"Sin",
     "Calculates the sine of the given input tensor, element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSinhOp:ONNX_Op<"Sinh", 
@@ -3056,7 +3056,7 @@ def ONNXSinhOp:ONNX_Op<"Sinh",
     "Calculates the hyperbolic sine of the given input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSizeOp:ONNX_Op<"Size", 
@@ -3066,7 +3066,7 @@ def ONNXSizeOp:ONNX_Op<"Size",
     "Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_size);
 }
 
 def ONNXSliceOp:ONNX_Op<"Slice", 
@@ -3113,7 +3113,7 @@ def ONNXSliceOp:ONNX_Op<"Slice",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$ends,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$axes,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$steps);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSoftmaxOp:ONNX_Op<"Softmax", 
@@ -3137,7 +3137,7 @@ def ONNXSoftmaxOp:ONNX_Op<"Softmax",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            DefaultValuedAttr<I64Attr, "1">:$axis);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSoftplusOp:ONNX_Op<"Softplus", 
@@ -3149,7 +3149,7 @@ def ONNXSoftplusOp:ONNX_Op<"Softplus",
     "the tensor elementwise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXSoftsignOp:ONNX_Op<"Softsign", 
@@ -3159,7 +3159,7 @@ def ONNXSoftsignOp:ONNX_Op<"Softsign",
     "Calculates the softsign (x/(1+|x|)) of the given input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSpaceToDepthOp:ONNX_Op<"SpaceToDepth", 
@@ -3172,7 +3172,7 @@ def ONNXSpaceToDepthOp:ONNX_Op<"SpaceToDepth",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            I64Attr:$blocksize);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXSplitOp:ONNX_Op<"Split", 
@@ -3186,7 +3186,7 @@ def ONNXSplitOp:ONNX_Op<"Split",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            DefaultValuedAttr<I64Attr, "0">:$axis,
            OptionalAttr<I64ArrayAttr>:$split);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_outputs);
 }
 
 def ONNXSplitToSequenceOp:ONNX_Op<"SplitToSequence", 
@@ -3208,7 +3208,7 @@ def ONNXSplitToSequenceOp:ONNX_Op<"SplitToSequence",
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$split,
            DefaultValuedAttr<I64Attr, "0">:$axis,
            DefaultValuedAttr<I64Attr, "1">:$keepdims);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output_sequence);
 }
 
 def ONNXSqrtOp:ONNX_Op<"Sqrt", 
@@ -3220,7 +3220,7 @@ def ONNXSqrtOp:ONNX_Op<"Sqrt",
     "the tensor elementwise. If x is negative, then it will return NaN."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXSqueezeOp:ONNX_Op<"Squeeze", 
@@ -3234,7 +3234,7 @@ def ONNXSqueezeOp:ONNX_Op<"Squeeze",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$axes);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_squeezed);
 }
 
 def ONNXStringNormalizerOp:ONNX_Op<"StringNormalizer", 
@@ -3256,7 +3256,7 @@ def ONNXStringNormalizerOp:ONNX_Op<"StringNormalizer",
            DefaultValuedAttr<I64Attr, "0">:$is_case_sensitive,
            OptionalAttr<StrAttr>:$locale,
            OptionalAttr<StrArrayAttr>:$stopwords);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXSubOp:ONNX_Op<"Sub", 
@@ -3269,7 +3269,7 @@ def ONNXSubOp:ONNX_Op<"Sub",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 
 def ONNXSumOp:ONNX_Op<"Sum", 
@@ -3281,7 +3281,7 @@ def ONNXSumOp:ONNX_Op<"Sum",
     "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md)."
   }];
   let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$data_0);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_sum);
 }
 
 def ONNXTanOp:ONNX_Op<"Tan", 
@@ -3291,7 +3291,7 @@ def ONNXTanOp:ONNX_Op<"Tan",
     "Calculates the tangent of the given input tensor, element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXTanhOp:ONNX_Op<"Tanh", 
@@ -3301,7 +3301,7 @@ def ONNXTanhOp:ONNX_Op<"Tanh",
     "Calculates the hyperbolic tangent of the given input tensor element-wise."
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXTfIdfVectorizerOp:ONNX_Op<"TfIdfVectorizer", 
@@ -3346,7 +3346,7 @@ def ONNXTfIdfVectorizerOp:ONNX_Op<"TfIdfVectorizer",
            OptionalAttr<I64ArrayAttr>:$pool_int64s,
            OptionalAttr<StrArrayAttr>:$pool_strings,
            OptionalAttr<F32ArrayAttr>:$weights);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXThresholdedReluOp:ONNX_Op<"ThresholdedRelu", 
@@ -3359,7 +3359,7 @@ def ONNXThresholdedReluOp:ONNX_Op<"ThresholdedRelu",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            DefaultValuedAttr<F32Attr, "1.0">:$alpha);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXTileOp:ONNX_Op<"Tile", 
@@ -3372,7 +3372,7 @@ def ONNXTileOp:ONNX_Op<"Tile",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$repeats);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXTopKOp:ONNX_Op<"TopK", 
@@ -3399,7 +3399,7 @@ def ONNXTopKOp:ONNX_Op<"TopK",
            DefaultValuedAttr<I64Attr, "-1">:$axis,
            DefaultValuedAttr<I64Attr, "1">:$largest,
            DefaultValuedAttr<I64Attr, "1">:$sorted);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Values, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Indices);
 }
 
 def ONNXTransposeOp:ONNX_Op<"Transpose", 
@@ -3412,7 +3412,7 @@ def ONNXTransposeOp:ONNX_Op<"Transpose",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            OptionalAttr<I64ArrayAttr>:$perm);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_transposed);
   let extraClassDeclaration = [{ 
     static StringRef getPermAttrName() { return "perm"; }
     }];
@@ -3501,7 +3501,7 @@ def ONNXUniqueOp:ONNX_Op<"Unique",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            OptionalAttr<I64Attr>:$axis,
            DefaultValuedAttr<I64Attr, "1">:$sorted);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>, AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_indices, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_inverse_indices, AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_counts);
 }
 
 def ONNXUnsqueezeOp:ONNX_Op<"Unsqueeze", 
@@ -3523,7 +3523,7 @@ def ONNXUnsqueezeOp:ONNX_Op<"Unsqueeze",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$data,
            DefaultValuedAttr<I64ArrayAttr, "{}">:$axes);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_expanded);
 }
 
 def ONNXUpsampleOp:ONNX_Op<"Upsample", 
@@ -3537,7 +3537,7 @@ def ONNXUpsampleOp:ONNX_Op<"Upsample",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$scales,
            DefaultValuedAttr<StrAttr, "nearest">:$mode);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
 }
 
 def ONNXWhereOp:ONNX_Op<"Where", 
@@ -3552,7 +3552,7 @@ def ONNXWhereOp:ONNX_Op<"Where",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$condition,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_output);
 }
 
 def ONNXXorOp:ONNX_Op<"Xor", 
@@ -3566,6 +3566,6 @@ def ONNXXorOp:ONNX_Op<"Xor",
   }];
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
            AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
-  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_C);
 }
 

--- a/src/pass/onnx_combine.td
+++ b/src/pass/onnx_combine.td
@@ -32,8 +32,8 @@ def HasOneUse : Constraint<CPred<"$0.hasOneUse()">>;
 
 def GemmAlpha : NativeCodeCall<"$_builder.getF32FloatAttr(1.0)">;
 def GemmBeta : NativeCodeCall<"$_builder.getF32FloatAttr(1.0)">;
-def GemmTransA : NativeCodeCall<"$_builder.getI32IntegerAttr(0)">;
-def GemmTransB : NativeCodeCall<"$_builder.getI32IntegerAttr(0)">;
+def GemmTransA : NativeCodeCall<"$_builder.getI64IntegerAttr(0)">;
+def GemmTransB : NativeCodeCall<"$_builder.getI64IntegerAttr(0)">;
 
 // onnx.add(onnx.matmul(%X, %Y), %Z) = onnx.Gemm(%X, %Y, %Z)
 def MulAddToGemmOptPattern : Pat<(ONNXAddOp (ONNXMatMulOp:$res $m1, $m2), $m3),

--- a/src/pass/onnx_combine.td
+++ b/src/pass/onnx_combine.td
@@ -30,9 +30,14 @@ def HasOneUse : Constraint<CPred<"$0.hasOneUse()">>;
 // Pattern-Match and Rewrite
 //===----------------------------------------------------------------------===//
 
+def GemmAlpha : NativeCodeCall<"$_builder.getF32FloatAttr(1.0)">;
+def GemmBeta : NativeCodeCall<"$_builder.getF32FloatAttr(1.0)">;
+def GemmTransA : NativeCodeCall<"$_builder.getI32IntegerAttr(0)">;
+def GemmTransB : NativeCodeCall<"$_builder.getI32IntegerAttr(0)">;
+
 // onnx.add(onnx.matmul(%X, %Y), %Z) = onnx.Gemm(%X, %Y, %Z)
 def MulAddToGemmOptPattern : Pat<(ONNXAddOp (ONNXMatMulOp:$res $m1, $m2), $m3),
-                                 (ONNXGemmOp $m1, $m2, $m3),
+                                 (ONNXGemmOp $m1, $m2, $m3, (GemmAlpha), (GemmBeta), (GemmTransA), (GemmTransB)),
 				 [(HasOneUse $res)]>;
 
 // ONNX_Op (onnx.Identity (%X)) = ONNX_Op (%X)

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -2,7 +2,7 @@
 
 func @test_matmul_add_simplification(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>, %a2: tensor<10x10xf32>) -> tensor<10x10xf32> {
   // CHECK-LABEL: test_matmul_add_simplification
-  // CHECK: %{{[0-9]+}} = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) : (tensor<10x10xf32>, tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
+  // CHECK: %{{[0-9]+}} = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : i64, transB = 0 : i64} : (tensor<10x10xf32>, tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
   %0 = "onnx.MatMul"(%a0, %a1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
   %1 = "onnx.Add"(%0, %a2) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
   "std.return"(%1) : (tensor<10x10xf32>) -> ()

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -535,7 +535,7 @@ func @test_add_with_broadcasting(%arg0 : tensor<?xf32>, %arg1 : tensor<?x10xf32>
 }
 
 func @test_softmax(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
-  %0 = "onnx.Softmax"(%arg0) {axis=1:i32} : (tensor<10x10xf32>) -> tensor<*xf32>
+  %0 = "onnx.Softmax"(%arg0) {axis=1:i64} : (tensor<10x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_softmax

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -32,120 +32,120 @@ func @test_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
 /// Default and required attributes.
 
 func @test_conv_no_bias_1(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_1
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x27x58xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x27x58xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x27x58xf32>
 
 /// kernel_shape attribute.
 
 func @test_conv_no_bias_2(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32, kernel_shape = [8, 9]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64, kernel_shape = [8, 9]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_2
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32, kernel_shape = [8, 9]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x25x56xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64, kernel_shape = [8, 9]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x25x56xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x25x56xf32>
 
 /// pads attribute.
 /// Use pads to make output size equal to input size by adding K - 1 to the result.
 
 func @test_conv_no_bias_3(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32, pads = [2, 4, 3, 5]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64, pads = [2, 4, 3, 5]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_3
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32, pads = [2, 4, 3, 5]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<1x5x32x64xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64, pads = [2, 4, 3, 5]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<1x5x32x64xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 
 /// auto_pad set to SAME_UPPER and SAME_LOWER.
 
 func @test_conv_no_bias_4(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_4
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<1x5x32x64xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<1x5x32x64xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 
 func @test_conv_no_bias_5(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_LOWER", group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_LOWER", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_5
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_LOWER", group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<1x5x32x64xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_LOWER", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<1x5x32x64xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 
 /// auto_pad set to VALID.
 
 func @test_conv_no_bias_6(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "VALID", group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "VALID", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_6
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "VALID", group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<1x5x27x55xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "VALID", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>) -> tensor<1x5x27x55xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x27x55xf32>
 
 /// With strides attribute.
 
 func @test_conv_no_bias_7(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_7
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x14x20xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x14x20xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x14x20xf32>
 
 /// auto_pad set to SAME_UPPER with strides attribute.
 /// The auto_pad will pas as if stride is equal to 1.
 
 func @test_conv_no_bias_8(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i32, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i64, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_8
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i32, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x16x22xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i64, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x16x22xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x16x22xf32>
 
 /// dilations attribute.
 
 func @test_conv_no_bias_9(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32, dilations = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64, dilations = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_9
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x20x42xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x20x42xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x20x42xf32>
 
 /// dilations attribute with stride.
 
 func @test_conv_no_bias_10(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i32, dilations = [2, 3], strides = [2, 2]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", group = 1 : i64, dilations = [2, 3], strides = [2, 2]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_10
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : i32, strides = [2, 2]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x10x21xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : i64, strides = [2, 2]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x10x21xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x10x21xf32>
 
 /// dilations attribute with auto_pad set to SAME_UPPER.
 
 func @test_conv_no_bias_11(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
-  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i32, dilations = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
+  %0 = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", group = 1 : i64, dilations = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL: test_conv_no_bias_11
-// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", dilations = [2, 3], group = 1 : i32} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x32x64xf32>
+// CHECK: [[RES_ATTR:%.+]] = "onnx.ConvNoBias"(%arg0, %arg1) {auto_pad = "SAME_UPPER", dilations = [2, 3], group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>) -> tensor<1x5x32x64xf32>
 // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>


### PR DESCRIPTION
attributes are added into parameters of Op in the TableGen  definition.
1. gen_doc.py
  * generate attributes in argument in onnxop.inc
  * add a function to attach any code for op definition in onnxop.inc. Do not modify onnxop.inc manually.
2. the default value of attributes is in the TableGen now. frontend_dialect_transformer.cpp is simplified. variant is kept, but can be removed.
3. use YourOP.nameAttr() to access attribute appearing in the argument list. getAttr("name") can get attributes defined, but not the default value
4. There is an issue with attributes with default value in pattern specification. Those attributes are required. Not sure it is an issue with MLIR or there is a solution. It is not a good solution to generate the default attribute again. Will look into it further. Current workaround is that attributes of GemmOp are not added into argument list.